### PR TITLE
fix llvm::ArrayRef crash issue

### DIFF
--- a/src/mlir/mlirfront/tilinglinalg/routing/routingmanager.cpp
+++ b/src/mlir/mlirfront/tilinglinalg/routing/routingmanager.cpp
@@ -261,8 +261,9 @@ mlir::func::FuncOp routingmanager::createroutingfuncByDim(MLIRContext* ctx, bool
         mlir::FunctionType ftype = builder.getFunctionType({itype,itype,itype,itype,itype,itype,itype,itype},{});
         func::FuncOp func = builder.create<func::FuncOp>(builder.getUnknownLoc(), "createroutebydim", ftype);
         //add parameter comments
-        llvm::ArrayRef<llvm::StringRef> argNames = {"mesh", "tensor", "splitnum", "axisidx", "partensor_dim", 
+         llvm::SmallVector<llvm::StringRef, 8> argNamesStorage = {"mesh", "tensor", "splitnum", "axisidx", "partensor_dim", 
                                                     "axisowner", "partensor_replicateon","partensor_singleowner"};
+        llvm::ArrayRef<llvm::StringRef> argNames(argNamesStorage);
         llvm::SmallVector<mlir::Attribute> argAttrs;
         for (size_t i = 0; i < argNames.size(); ++i) {
             std::string argName = "arg" + std::to_string(i) + "_name";


### PR DESCRIPTION
if do llvm::ArrayRef<llvm::StringRef> argNames = {"mesh", "tensor", "splitnum", "axisidx", "partensor_dim"}; the argNames[0] will get a very big string size and the string variable of it point to a invalid address

it is because such contruct used a temporary llvm::stringref which get release after contruct, it should be this version llvm issue, as i not found it in the higher version llvm.