### PR TITLE
GEMM opt

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,3 +7,5 @@ BasedOnStyle: LLVM
 IndentWidth: 4
 ColumnLimit: 120
 TabWidth: 4
+SortIncludes: false
+

--- a/README.md
+++ b/README.md
@@ -222,7 +222,9 @@ The debug level value is a bitfield:
 |------|-----|-------|----------|
 | `DISABLE_MULTID_DIM_DMA` | 4 | `16` | Suppress multi-dimensional DMA; force linear `__Runtime_dma_bd_config` |
 | `DISABLE_PARTITIONTEARDOWN` | 5 | `32` | Skip `XAie_PartitionTeardown` in `__Runtime_device_teardown` |
+| `MM2SBDFINISH_COUNTER` | 6 | `64` | Arm probe-tile MM2S ch0/ch1 BD-finished counters; read via `__Runtime_perfcnt_read_mm2s_probe`. Requires `--profiling` |
 | `AIE_DMA_ISSUE_COUNT` | 7 | `128` | Use `XAie_PartitionInitialize_v2`/`_v2` teardown to arm DMA txn perf counters (whole partition, MM2S ch0) |
+| `CORE_PERF_COUNTER` | 8 | `256` | Arm core-module cycle counters (active / vector-instr / stream-stall / lock-stall) on the probe tile. Requires `--profiling` |
 
 ### Examples
 
@@ -238,6 +240,28 @@ The debug level value is a bitfield:
 The pragma is detected during preprocessing and emits a strong symbol override of `g_runtime_debug_level` into the generated `host.cc`. The runtime in `aie_runtime.c` defines this variable as a weak symbol with default `0`, so the linker picks the user-specified value when present.
 
 This works for both single-tile (`aiehlc`) and multi-tile (`tilinglinalg`) compilation paths.
+
+## Build Options
+
+Two host-build toggles, both off by default and both compile-time (they change how
+`aie_runtime.c` is compiled, so they need a rebuild to take effect):
+
+| Flag | Define | Effect |
+|------|--------|--------|
+| `--profiling` | `-DAIEHLC_PROFILING=1` | Compile in the PS PMU profiling layer: launch-phase timers (kload / bdcfg / coreen / startio / wait_io) and the `[PERF]` summary. Off, the `RT_PROF_*` macros expand to nothing and the reader functions return zeros. |
+| `--skip-bss` | `-DAIEHLC_SKIP_BSS_DEFAULT=1` | Load only PT_LOAD segments with file bytes, skipping pure-`.bss` zero-init on kernel load. Safe only when no global is read before being written — the DMA-fed window buffers qualify. |
+
+```bash
+source script/aiehlc.sh --platform baremetal --aie-version 5 --profiling --skip-bss \
+    --runtime-source-file ./example/tileprogram/ccode/simplematmul2_prof.cc
+```
+
+Note the `MM2SBDFINISH_COUNTER` and `CORE_PERF_COUNTER` pragma bits above are inert
+without `--profiling`: the counters are armed by code that only exists in a profiling
+build, so the pragma alone reports zeros.
+
+`--skip-bss` must be the compile define rather than the `AIEHLC_SKIP_BSS` environment
+variable on baremetal, where newlib `getenv()` always returns `NULL`.
 
 ## Debug Tools
 

--- a/example/tileprogram/ccode/simplematmul2_prof.cc
+++ b/example/tileprogram/ccode/simplematmul2_prof.cc
@@ -1,0 +1,513 @@
+/******************************************************************************
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+#define M 256
+#define K 256
+#define N 256
+#define HW_ROWS 4
+#define HW_COLS 4
+#define TILE_M 64
+#define TILE_N 64
+#define KCHUNK 64
+#define NUM_MATRICES 1
+#define PASSTHROUGH_KERNEL 0
+#define PASSTHROUGH_VECTORIZED 1
+#include "simplematmul.h"
+#pragma aie_debug_level(0 | AIE_DEBUG_FLAG_DISABLE_PARTITIONTEARDOWN | AIE_DEBUG_FLAG_MM2SBDFINISH_COUNTER |           \
+                        AIE_DEBUG_FLAG_CORE_PERF_COUNTER)
+
+extern void __Runtime_core_perf_read_probe(uint32_t *active, uint32_t *vec_instr, uint32_t *stream_stall,
+                                           uint32_t *lock_stall);
+extern void __Runtime_perfcnt_read_mm2s_probe(uint32_t *ch0, uint32_t *ch1);
+extern int __Runtime_core_perf_probe_valid(void);
+extern void __Runtime_wait_io_cycles(unsigned long long *cycles, unsigned int *calls);
+extern void __Runtime_phase_cycles(unsigned long long *cyc, unsigned int *calls);
+extern void __Runtime_bd_subphase_cycles(unsigned long long *init_cyc, unsigned int *init_n,
+                                         unsigned long long *write_cyc, unsigned int *write_n);
+extern void __Runtime_bd_midtail_cycles(unsigned long long *mid_cyc, unsigned int *mid_n, unsigned long long *tail_cyc,
+                                        unsigned int *tail_n);
+extern void __Runtime_bd_mid3_cycles(unsigned long long *gtt_cyc, unsigned int *gtt_n, unsigned long long *saddr_cyc,
+                                     unsigned int *saddr_n, unsigned long long *en_cyc, unsigned int *en_n);
+extern void __Runtime_kload_split_cycles(unsigned long long *elf_cyc, unsigned int *elf_n, unsigned long long *rst_cyc,
+                                         unsigned int *rst_n);
+extern void __Runtime_wait_io_iters(unsigned long long *iters);
+
+constexpr aie::GemmSpace RowBA = {.policy = {.map = {.act = aie::Pattern::Broadcast, .layout = aie::Layout::Row},
+                                             .mat = {.pad = aie::PadMaterialize::DDR, .im2col = aie::Im2col::None},
+                                             .sched = {.pp_depth = 2, .l1_budget = aie::Bytes{8192}}},
+                                  .d1 = {.fullsize = M, .tile_size = TILE_M, .stride = TILE_M},
+                                  .d2 = {.fullsize = K, .tile_size = KCHUNK, .stride = KCHUNK}};
+constexpr aie::GemmSpace ColBB = {.policy = {.map = {.wgt = aie::Pattern::Broadcast, .layout = aie::Layout::Col},
+                                             .mat = {.pad = aie::PadMaterialize::DDR, .im2col = aie::Im2col::None},
+                                             .sched = {.pp_depth = 2, .l1_budget = aie::Bytes{8192}}},
+                                  .d1 = {.fullsize = N, .tile_size = TILE_N, .stride = TILE_N},
+                                  .d2 = {.fullsize = K, .tile_size = KCHUNK, .stride = KCHUNK}};
+constexpr aie::GemmSpace LtoR_Merge = {
+    .policy = {.map = {.layout = aie::Layout::Row, .merge_order = aie::Flow::LeftToRight},
+               .mat = {.pad = aie::PadMaterialize::DDR, .im2col = aie::Im2col::None},
+               .sched = {.pp_depth = 2, .l1_budget = aie::Bytes{8192}}},
+    .d1 = {.fullsize = M, .tile_size = TILE_M, .stride = TILE_M},
+    .d2 = {.fullsize = N, .tile_size = TILE_N, .stride = TILE_N}};
+
+__global__ void matmul(aie::port<input_window_int8 *, RowBA> win_a, aie::port<input_window_int8 *, ColBB> win_b,
+                       aie::port<output_window_int8 *, LtoR_Merge> win_c) {
+    const int tile_rows = aie::get_tile_rows();
+    const int tile_cols = aie::get_tile_cols();
+    const int eff_k = aie::get_effective_k();
+    const int k_rounds = aie::get_k_rounds();
+    const int num_a_rounds = aie::get_num_rounds(win_a);
+    const int num_b_rounds = aie::get_num_rounds(win_b);
+    const int num_c_rounds = aie::get_num_rounds(win_c);
+    const int buf_sz_a = aie::get_buffer_size(win_a);
+    const int buf_sz_c = aie::get_buffer_size(win_c);
+    const int m_rounds = aie::get_spatial_multiple_rounds(win_a);
+    const int n_rounds = aie::get_spatial_multiple_rounds(win_b);
+    const int cols_per_round = aie::get_buffer_size(win_b) / eff_k;
+
+    alignas(aie::vector_decl_align) int8_t all_A[tile_rows * eff_k];
+#if PASSTHROUGH_KERNEL
+    const int buf_sz_b = aie::get_buffer_size(win_b);
+#if PASSTHROUGH_VECTORIZED
+    constexpr int VW = 32;
+    for (int mr = 0; mr < m_rounds * n_rounds; mr++) {
+        aie::vector<int8, VW> vbsum = aie::zeros<int8, VW>();
+        for (int kr = 0; kr < k_rounds; kr++) {
+            for (int ra = 0; ra < num_a_rounds; ra++) {
+                int8_t *A_ptr = (int8_t *)acquire_input_window(win_a);
+                for (int i = 0; i < buf_sz_a; i += VW)
+                    aie::store_v(all_A + ra * buf_sz_a + i, aie::load_v<VW>(A_ptr + i));
+                release_input_window(win_a);
+            }
+            for (int rb = 0; rb < num_b_rounds; rb++) {
+                int8_t *B_ptr = (int8_t *)acquire_input_window(win_b);
+                for (int i = 0; i < buf_sz_b; i += VW)
+                    vbsum = aie::add(vbsum, aie::load_v<VW>(B_ptr + i));
+                release_input_window(win_b);
+            }
+        }
+        alignas(aie::vector_decl_align) int8_t local_out[tile_rows * tile_cols];
+        for (int idx = 0; idx < tile_rows * tile_cols; idx += VW)
+            aie::store_v(local_out + idx, aie::add(aie::load_v<VW>(all_A + idx), vbsum));
+        for (int rc = 0; rc < num_c_rounds; rc++) {
+            int8_t *out = (int8_t *)acquire_output_window(win_c);
+            for (int i = 0; i < buf_sz_c; i += VW)
+                aie::store_v(out + i, aie::load_v<VW>(local_out + rc * buf_sz_c + i));
+            release_output_window(win_c);
+        }
+    }
+#else
+    for (int mr = 0; mr < m_rounds * n_rounds; mr++) {
+        int8_t bsum = 0;
+        for (int kr = 0; kr < k_rounds; kr++) {
+            for (int ra = 0; ra < num_a_rounds; ra++) {
+                int8_t *A_ptr = (int8_t *)acquire_input_window(win_a);
+                for (int i = 0; i < buf_sz_a; i++)
+                    all_A[ra * buf_sz_a + i] = A_ptr[i];
+                release_input_window(win_a);
+            }
+            for (int rb = 0; rb < num_b_rounds; rb++) {
+                int8_t *B_ptr = (int8_t *)acquire_input_window(win_b);
+                for (int i = 0; i < buf_sz_b; i++)
+                    bsum = (int8_t)(bsum + B_ptr[i]);
+                release_input_window(win_b);
+            }
+        }
+        int8_t local_out[tile_rows * tile_cols];
+        for (int idx = 0; idx < tile_rows * tile_cols; idx++)
+            local_out[idx] = (int8_t)(all_A[idx] + bsum);
+        for (int rc = 0; rc < num_c_rounds; rc++) {
+            int8_t *out = (int8_t *)acquire_output_window(win_c);
+            const int rows_per_c_round = buf_sz_c / tile_cols;
+            for (int i = 0; i < rows_per_c_round; i++)
+                for (int j = 0; j < tile_cols; j++)
+                    out[i * tile_cols + j] = local_out[rc * rows_per_c_round * tile_cols + i * tile_cols + j];
+            release_output_window(win_c);
+        }
+    }
+#endif
+#else
+    int32_t acc_buf[tile_rows * tile_cols];
+
+    for (int mr = 0; mr < m_rounds * n_rounds; mr++) {
+        for (int idx = 0; idx < tile_rows * tile_cols; idx++)
+            acc_buf[idx] = 0;
+
+        for (int kr = 0; kr < k_rounds; kr++) {
+            for (int ra = 0; ra < num_a_rounds; ra++) {
+                int8_t *A_ptr = (int8_t *)acquire_input_window(win_a);
+                for (int i = 0; i < buf_sz_a; i++)
+                    all_A[ra * buf_sz_a + i] = A_ptr[i];
+                release_input_window(win_a);
+            }
+
+            for (int rb = 0; rb < num_b_rounds; rb++) {
+                int8_t *B_ptr = (int8_t *)acquire_input_window(win_b);
+
+                for (int i = 0; i < tile_rows; i++) {
+                    const int8_t *Arow = all_A + i * eff_k;
+                    aie::vector<int8, 16> a0 = aie::load_v<16>(Arow);
+                    aie::vector<int8, 16> a1 = aie::load_v<16>(Arow + 16);
+                    aie::vector<int8, 16> a2 = aie::load_v<16>(Arow + 32);
+                    aie::vector<int8, 16> a3 = aie::load_v<16>(Arow + 48);
+
+                    for (int j = 0; j < cols_per_round; j++) {
+                        const int8_t *Bcol = B_ptr + j * eff_k;
+                        aie::accum<acc32, 16> acc0 = aie::mul(a0, aie::load_v<16>(Bcol));
+                        aie::accum<acc32, 16> acc1 = aie::mul(a1, aie::load_v<16>(Bcol + 16));
+                        aie::accum<acc32, 16> acc2 = aie::mul(a2, aie::load_v<16>(Bcol + 32));
+                        aie::accum<acc32, 16> acc3 = aie::mul(a3, aie::load_v<16>(Bcol + 48));
+                        aie::accum<acc32, 16> acc01 = aie::add(acc0, acc1);
+                        aie::accum<acc32, 16> acc23 = aie::add(acc2, acc3);
+                        aie::accum<acc32, 16> acc_all = aie::add(acc01, acc23);
+                        acc_buf[i * tile_cols + j] += aie::reduce_add(acc_all.to_vector<int32>());
+                    }
+                }
+                release_input_window(win_b);
+            }
+        }
+
+        int8_t local_out[tile_rows * tile_cols];
+        for (int idx = 0; idx < tile_rows * tile_cols; idx++) {
+            int32_t v = acc_buf[idx];
+            local_out[idx] = (int8_t)(v > 127 ? 127 : (v < -128 ? -128 : v));
+        }
+
+        for (int rc = 0; rc < num_c_rounds; rc++) {
+            int8_t *out = (int8_t *)acquire_output_window(win_c);
+            const int rows_per_c_round = buf_sz_c / tile_cols;
+            for (int i = 0; i < rows_per_c_round; i++)
+                for (int j = 0; j < tile_cols; j++)
+                    out[i * tile_cols + j] = local_out[rc * rows_per_c_round * tile_cols + i * tile_cols + j];
+            release_output_window(win_c);
+        }
+    }
+#endif
+}
+
+#define SPOT_STRIDE 4093
+#define MAX_SPOTS ((M * N) / SPOT_STRIDE + 2)
+static int g_spot_idx[MAX_SPOTS];
+static int8_t g_spot_gold[MAX_SPOTS];
+static int g_num_spots = 0;
+
+static void build_spots(const int8_t *A, const int8_t *B) {
+    g_num_spots = 0;
+    for (int idx = 0; idx < M * N; idx += SPOT_STRIDE)
+        g_spot_idx[g_num_spots++] = idx;
+    if (g_num_spots == 0 || g_spot_idx[g_num_spots - 1] != M * N - 1)
+        g_spot_idx[g_num_spots++] = M * N - 1;
+    for (int s = 0; s < g_num_spots; s++) {
+        int idx = g_spot_idx[s];
+        int i = idx / N, j = idx % N;
+        int16_t acc = 0;
+        for (int k = 0; k < K; k++)
+            acc += (int16_t)A[i * K + k] * (int16_t)B[j * K + k];
+        if (acc > 127)
+            acc = 127;
+        else if (acc < -128)
+            acc = -128;
+        g_spot_gold[s] = (int8_t)acc;
+    }
+}
+
+static int prof_verify(const int8_t *C) {
+    int mismatches = 0;
+    for (int s = 0; s < g_num_spots; s++) {
+        int idx = g_spot_idx[s];
+        if (C[idx] != g_spot_gold[s]) {
+            if (mismatches < 8)
+                printf("  mismatch C[%d,%d] got %d exp %d\n", idx / N, idx % N, (int)C[idx], (int)g_spot_gold[s]);
+            mismatches++;
+        }
+    }
+    if (mismatches == 0)
+        printf("RESULT: PASS (spot-check: all %d sampled of %d elements match)\n", g_num_spots, M * N);
+    else
+        printf("RESULT: FAIL (%d / %d spot mismatches)\n", mismatches, g_num_spots);
+    return mismatches;
+}
+
+int main() {
+    printf("\n=== aiehlc GEMM profiling ===\n");
+    printf("  C[%dx%d] = A[%dx%d] * B^T[%dx%d], int8, %dx%d mesh (%d tiles)\n", M, N, M, K, N, K, HW_ROWS, HW_COLS,
+           HW_ROWS * HW_COLS);
+
+    __ps_pmccntr_enable();
+    unsigned long long pc_init0 = __ps_pmccntr();
+    aieSetDevice(0);
+    aieArray device;
+    aieMesh mesh = device.partition({0, 3, 0, 5}, HW_ROWS, HW_COLS);
+    unsigned long long pc_init1 = __ps_pmccntr();
+
+    unsigned long long pc_setup0 = __ps_pmccntr();
+    int8_t *A = (int8_t *)device.alloc(M * K * sizeof(int8_t) * 4);
+    int8_t *B = (int8_t *)device.alloc(K * N * sizeof(int8_t) * 4);
+    int8_t *C = (int8_t *)device.alloc(M * N * sizeof(int8_t) * 4);
+    for (int i = 0; i < M * K; i++)
+        A[i] = (int8_t)((i % 7) - 3);
+    for (int i = 0; i < K * N; i++)
+        B[i] = (int8_t)((i % 5) - 2);
+    extern void __Runtime_sync_for_dev(XAie_DevInst * dev, void *ptr, __SIZE_TYPE__ size);
+    for (int i = 0; i < M * N; i++)
+        C[i] = (int8_t)0x5A;
+    __Runtime_sync_for_dev(device._dev, C, M * N * sizeof(int8_t) * 4);
+    printf("[exp07] poisoned device C with 0x5A and flushed to DDR\n");
+
+    build_spots(A, B);
+    printf("[spot] verifying %d sampled outputs (stride %d) of %d total\n", g_num_spots, SPOT_STRIDE, M * N);
+
+    unsigned long long pc_setup1 = __ps_pmccntr();
+
+    const uint64_t MAX_POLL = 500000000ULL;
+    XTime t0, t1;
+    unsigned long long cv0 = __ps_cntvct();
+    unsigned long long pc0 = __ps_pmccntr();
+    XTime_GetTime(&t0);
+    matmul<<<mesh>>>(A, B, C, M, N, K);
+    unsigned long long pc_mid = __ps_pmccntr();
+    uint64_t polls = 0;
+    int complete = 0;
+    unsigned long long poll_sync_cyc = 0ULL, poll_cmp_cyc = 0ULL;
+    do {
+        unsigned long long __ps0 = __ps_pmccntr();
+        device.synchronizecpu(C, M * N * sizeof(int8_t) * 4);
+        poll_sync_cyc += (__ps_pmccntr() - __ps0);
+        unsigned long long __pc0 = __ps_pmccntr();
+        complete = 1;
+#if !PASSTHROUGH_KERNEL
+        for (int s = 0; s < g_num_spots; s++) {
+            if (C[g_spot_idx[s]] != g_spot_gold[s]) {
+                complete = 0;
+                break;
+            }
+        }
+#endif
+        poll_cmp_cyc += (__ps_pmccntr() - __pc0);
+        polls++;
+    } while (!complete && polls < MAX_POLL);
+    XTime_GetTime(&t1);
+    unsigned long long cv1 = __ps_cntvct();
+    unsigned long long pc1 = __ps_pmccntr();
+    if (!complete)
+        printf("  WARNING: completion barrier hit MAX_POLL=%llu without full result\n", (unsigned long long)MAX_POLL);
+
+    uint64_t raw_counts = (uint64_t)(t1 - t0);
+    uint64_t timer_hz = (uint64_t)COUNTS_PER_SECOND;
+    double wall_ms = 1000.0 * (double)raw_counts / (double)timer_hz;
+    double wall_us = 1.0e6 * (double)raw_counts / (double)timer_hz;
+    double tick_ns = 1.0e9 / (double)timer_hz;
+    double total_flops = 2.0 * (double)M * (double)N * (double)K;
+    double gflops_wall = (wall_ms > 0.0) ? total_flops / (wall_ms * 1e-3) / 1e9 : 0.0;
+
+    uint32_t active = 0, vec = 0, sstall = 0, lstall = 0, mm0 = 0, mm1 = 0;
+    int have_core = __Runtime_core_perf_probe_valid();
+    __Runtime_core_perf_read_probe(&active, &vec, &sstall, &lstall);
+    __Runtime_perfcnt_read_mm2s_probe(&mm0, &mm1);
+
+    double tile_macs = (double)(M / HW_ROWS) * (double)(N / HW_COLS) * (double)K;
+    double tile_flops = 2.0 * tile_macs;
+    double total_budget = (double)active + (double)sstall + (double)lstall;
+    double compute_pct = total_budget ? 100.0 * (double)active / total_budget : 0.0;
+    double stream_pct = total_budget ? 100.0 * (double)sstall / total_budget : 0.0;
+    double lock_pct = total_budget ? 100.0 * (double)lstall / total_budget : 0.0;
+    double macs_per_vec = vec ? tile_macs / (double)vec : 0.0;
+    (void)tile_flops;
+
+    const double DEVICE_INT8_TOPS = 184.0;
+    const int DEVICE_TILES = 144;
+    int array_tiles = HW_ROWS * HW_COLS;
+    double array_peak_gops = DEVICE_INT8_TOPS * 1000.0 * (double)array_tiles / (double)DEVICE_TILES;
+    double util_pct = array_peak_gops ? 100.0 * gflops_wall / array_peak_gops : 0.0;
+
+    printf("\n--- Layer 0: pre-launch setup (outside timed window) ---\n");
+    printf("  [pmccntr] device_init: %llu cyc  (aieSetDevice + partition)\n",
+           (unsigned long long)(pc_init1 - pc_init0));
+    printf("  [pmccntr] data_setup:  %llu cyc  (alloc + A/B init + poison-C + golden compute)\n",
+           (unsigned long long)(pc_setup1 - pc_setup0));
+
+    printf("\n--- Layer 1: PS wall-clock (end-to-end launch) ---\n");
+    printf("  raw counts:        %llu  (t1 - t0)\n", (unsigned long long)raw_counts);
+    printf("  timer freq:        %llu Hz  (COUNTS_PER_SECOND; 1 tick = %.3f ns)\n", (unsigned long long)timer_hz,
+           tick_ns);
+    printf("  total time:        %.6f ms  (%.3f us)\n", wall_ms, wall_us);
+    printf("  completion polls:  %llu  (DDR read-back until full result present)\n", (unsigned long long)polls);
+    printf("  wall GFLOPS:       %.3f GOPS  (2*M*N*K / total_ms)\n", gflops_wall);
+    printf("  note: launch -> full result in DDR (async launch + poll-to-result barrier)\n");
+    {
+        unsigned long long cv_raw = (cv1 >= cv0) ? (cv1 - cv0) : 0ULL;
+        unsigned long long cv_hz = __ps_cntfrq();
+        double cv_ms = cv_hz ? 1000.0 * (double)cv_raw / (double)cv_hz : 0.0;
+        printf("  [cntvct] raw:      %llu counts  freq: %llu Hz  wall: %.6f ms\n", cv_raw, cv_hz, cv_ms);
+    }
+    {
+        unsigned long long pc_raw = (pc1 >= pc0) ? (pc1 - pc0) : 0ULL;
+        unsigned long long pmcr = __ps_pmcr();
+        unsigned int d_bit = (unsigned int)((pmcr >> 3) & 1ULL);
+        printf("  [pmccntr] raw:     %llu cycles  pmcr:0x%llx (D=%u, %s)\n", pc_raw, pmcr, d_bit,
+               d_bit ? "counts=CPUcyc/64" : "counts=CPUcyc");
+        unsigned long long pc_launch = (pc_mid >= pc0) ? (pc_mid - pc0) : 0ULL;
+        unsigned long long pc_poll = (pc1 >= pc_mid) ? (pc1 - pc_mid) : 0ULL;
+        printf("  [pmccntr] launch:  %llu cycles  poll: %llu cycles\n", pc_launch, pc_poll);
+        unsigned long long wio_cyc = 0ULL;
+        unsigned int wio_calls = 0U;
+        __Runtime_wait_io_cycles(&wio_cyc, &wio_calls);
+        double wio_pct = (pc_launch > 0) ? 100.0 * (double)wio_cyc / (double)pc_launch : 0.0;
+        printf("  [phase] wait_io:   %llu cycles over %u calls  (=%.1f%% of launch)\n", wio_cyc, wio_calls, wio_pct);
+        unsigned long long wio_iters = 0ULL;
+        __Runtime_wait_io_iters(&wio_iters);
+        double wio_cyc_per_iter = (wio_iters > 0) ? (double)wio_cyc / (double)wio_iters : 0.0;
+        double wio_cyc_per_call = (wio_calls > 0) ? (double)wio_cyc / (double)wio_calls : 0.0;
+        printf("  [wait_io] poll iters: %llu total  (%.1f cyc/iter avg, %.0f avg cyc/call)\n", wio_iters,
+               wio_cyc_per_iter, wio_cyc_per_call);
+        double sync_pct = (pc_poll > 0) ? 100.0 * (double)poll_sync_cyc / (double)pc_poll : 0.0;
+        double cmp_pct = (pc_poll > 0) ? 100.0 * (double)poll_cmp_cyc / (double)pc_poll : 0.0;
+        printf("  [poll] synchronizecpu: %llu cyc over %llu calls  (=%.1f%% of poll)\n", poll_sync_cyc,
+               (unsigned long long)polls, sync_pct);
+        printf("  [poll] compare (C vs golden): %llu cyc over %llu calls  (=%.1f%% of poll)\n", poll_cmp_cyc,
+               (unsigned long long)polls, cmp_pct);
+        unsigned long long ph[4] = {0, 0, 0, 0};
+        unsigned int phc[4] = {0, 0, 0, 0};
+        __Runtime_phase_cycles(ph, phc);
+        const char *phn[4] = {"kload  ", "bdcfg  ", "coreen ", "startio"};
+        for (int i = 0; i < 4; i++) {
+            double p = (pc_launch > 0) ? 100.0 * (double)ph[i] / (double)pc_launch : 0.0;
+            printf("  [phase] %s: %llu cycles over %u calls  (=%.1f%% of launch)\n", phn[i], ph[i], phc[i], p);
+        }
+        unsigned long long bi = 0ULL, bw = 0ULL;
+        unsigned int bin = 0U, bwn = 0U;
+        __Runtime_bd_subphase_cycles(&bi, &bin, &bw, &bwn);
+        double bip = (ph[1] > 0) ? 100.0 * (double)bi / (double)ph[1] : 0.0;
+        double bwp = (ph[1] > 0) ? 100.0 * (double)bw / (double)ph[1] : 0.0;
+        printf("  [bdcfg] descinit: %llu cyc over %u  (=%.1f%% of bdcfg)\n", bi, bin, bip);
+        printf("  [bdcfg] writebd:  %llu cyc over %u  (=%.1f%% of bdcfg)\n", bw, bwn, bwp);
+        unsigned long long bmid = 0ULL, btail = 0ULL;
+        unsigned int bmidn = 0U, btailn = 0U;
+        __Runtime_bd_midtail_cycles(&bmid, &bmidn, &btail, &btailn);
+        double bmp = (ph[1] > 0) ? 100.0 * (double)bmid / (double)ph[1] : 0.0;
+        double btp = (ph[1] > 0) ? 100.0 * (double)btail / (double)ph[1] : 0.0;
+        unsigned long long bacct = bi + bw + bmid + btail;
+        double bap = (ph[1] > 0) ? 100.0 * (double)bacct / (double)ph[1] : 0.0;
+        printf("  [bdcfg] mid:      %llu cyc over %u  (=%.1f%% of bdcfg)\n", bmid, bmidn, bmp);
+        printf("  [bdcfg] tail:     %llu cyc over %u  (=%.1f%% of bdcfg)\n", btail, btailn, btp);
+        printf("  [bdcfg] accounted (init+write+mid+tail): %llu cyc  (=%.1f%% of bdcfg)\n", bacct, bap);
+        unsigned long long bgtt = 0ULL, bsa = 0ULL, ben = 0ULL;
+        unsigned int bgttn = 0U, bsan = 0U, benn = 0U;
+        __Runtime_bd_mid3_cycles(&bgtt, &bgttn, &bsa, &bsan, &ben, &benn);
+        double gttp = (bmid > 0) ? 100.0 * (double)bgtt / (double)bmid : 0.0;
+        double sap = (bmid > 0) ? 100.0 * (double)bsa / (double)bmid : 0.0;
+        double enp = (bmid > 0) ? 100.0 * (double)ben / (double)bmid : 0.0;
+        unsigned long long bres = (bmid > bgtt + bsa + ben) ? (bmid - bgtt - bsa - ben) : 0ULL;
+        double resp = (bmid > 0) ? 100.0 * (double)bres / (double)bmid : 0.0;
+        printf("  [mid] gettiletype: %llu cyc over %u  (=%.1f%% of mid)\n", bgtt, bgttn, gttp);
+        printf("  [mid] setaddr:     %llu cyc over %u  (=%.1f%% of mid)\n", bsa, bsan, sap);
+        printf("  [mid] enablebd:    %llu cyc over %u  (=%.1f%% of mid)\n", ben, benn, enp);
+        printf("  [mid] residual (setlock/nextbd/pkt/ooo+printf): %llu cyc  (=%.1f%% of mid)\n", bres, resp);
+        unsigned long long kelf = 0ULL, krst = 0ULL;
+        unsigned int kelfn = 0U, krstn = 0U;
+        __Runtime_kload_split_cycles(&kelf, &kelfn, &krst, &krstn);
+        double kep = (ph[0] > 0) ? 100.0 * (double)kelf / (double)ph[0] : 0.0;
+        double krp = (ph[0] > 0) ? 100.0 * (double)krst / (double)ph[0] : 0.0;
+        printf("  [kload] loadelf:  %llu cyc over %u  (=%.1f%% of kload)\n", kelf, kelfn, kep);
+        printf("  [kload] corerst:  %llu cyc over %u  (=%.1f%% of kload)\n", krst, krstn, krp);
+        unsigned long long ph_total = ph[0] + ph[1] + ph[2] + ph[3] + wio_cyc;
+        unsigned long long unacct = (pc_launch > ph_total) ? (pc_launch - ph_total) : 0ULL;
+        double unacct_p = (pc_launch > 0) ? 100.0 * (double)unacct / (double)pc_launch : 0.0;
+        printf("  [launch] unaccounted (lock_init+glue): %llu cyc  (=%.1f%% of launch)\n", unacct, unacct_p);
+        printf("  [launch] BUDGET SUMMARY (all in cycles):\n");
+        printf("    kload    %10llu  (%.1f%%)\n", ph[0],
+               (pc_launch > 0) ? 100.0 * (double)ph[0] / (double)pc_launch : 0.0);
+        printf("    bdcfg    %10llu  (%.1f%%)\n", ph[1],
+               (pc_launch > 0) ? 100.0 * (double)ph[1] / (double)pc_launch : 0.0);
+        printf("    lockinit %10llu  (%.1f%%) [unaccounted proxy]\n", unacct, unacct_p);
+        printf("    startio  %10llu  (%.1f%%)\n", ph[3],
+               (pc_launch > 0) ? 100.0 * (double)ph[3] / (double)pc_launch : 0.0);
+        printf("    coreen   %10llu  (%.1f%%)\n", ph[2],
+               (pc_launch > 0) ? 100.0 * (double)ph[2] / (double)pc_launch : 0.0);
+        printf("    wait_io  %10llu  (%.1f%%)\n", wio_cyc,
+               (pc_launch > 0) ? 100.0 * (double)wio_cyc / (double)pc_launch : 0.0);
+        printf("    TOTAL    %10llu  (launch=%llu)\n", ph_total + unacct, pc_launch);
+    }
+
+    printf("\n--- Layer 2: DMA stream (probe tile MM2S BD finished) ---\n");
+    printf("  MM2S ch0 BDs done: %u\n", mm0);
+    printf("  MM2S ch1 BDs done: %u\n", mm1);
+
+    printf("\n--- Layer 3: AIE core tile cycle budget (probe = first compute tile) ---\n");
+    if (!have_core)
+        printf("  [no probe tile armed]\n");
+    printf("  core-state split (sampled window; ratios valid, absolute cycles are a sub-window):\n");
+    printf("    compute:      %.2f%%  (%u cyc active/executing)\n", compute_pct, active);
+    printf("    stream stall: %.2f%%  (%u cyc)  [waiting for window data]\n", stream_pct, sstall);
+    printf("    lock stall:   %.2f%%  (%u cyc)  [waiting for buffer lock/DMA]\n", lock_pct, lstall);
+
+    printf("\n--- Vector density (full-run, window-independent) ---\n");
+    printf("  vector instrs:     %u  (INSTR_VECTOR over whole run)\n", vec);
+    printf("  MACs/vector-instr: %.2f  (tile MACs %.3g / vec instrs; higher = denser vectorization)\n", macs_per_vec,
+           tile_macs);
+    printf("  note: an aie::mmul<4,16,8> retires ~64 MAC/op; a mul+reduce_add dot-product is much lower,\n");
+    printf("        so a low value here flags the microkernel (not feed/locks) as the compute-side lever.\n");
+
+    printf("\n--- Hardware utilization (INT8, same yardstick as AEG) ---\n");
+    printf("  array INT8 peak:   %.1f GOPS  (%d/%d tiles of %.0f TOPS device)\n", array_peak_gops, array_tiles,
+           DEVICE_TILES, DEVICE_INT8_TOPS);
+    printf("  measured (wall):   %.3f GOPS  ->  %.4f %% of array peak\n", gflops_wall, util_pct);
+
+    printf("\n--- Correctness ---\n");
+    unsigned long long pc_verify0 = __ps_pmccntr();
+#if PASSTHROUGH_KERNEL
+    int result = 0;
+    printf("RESULT: SKIP (passthrough kernel — feed/DMA floor measurement, no compute)\n");
+    (void)prof_verify;
+#else
+    int result = prof_verify(C);
+#endif
+    unsigned long long pc_verify1 = __ps_pmccntr();
+
+    unsigned long long pc_free0 = __ps_pmccntr();
+    device.free(A);
+    device.free(B);
+    device.free(C);
+    unsigned long long pc_free1 = __ps_pmccntr();
+
+    printf("\n--- Layer 0 (post-launch): out-of-timed-window teardown ---\n");
+    printf("  [pmccntr] verify:      %llu cyc  (prof_verify spot-check compare)\n",
+           (unsigned long long)(pc_verify1 - pc_verify0));
+    printf("  [pmccntr] device.free: %llu cyc  (free A+B+C)\n", (unsigned long long)(pc_free1 - pc_free0));
+
+    {
+        unsigned long long ph[4] = {0, 0, 0, 0};
+        unsigned int phc[4] = {0, 0, 0, 0};
+        __Runtime_phase_cycles(ph, phc);
+        unsigned long long wio_cyc2 = 0ULL;
+        unsigned int wio_calls2 = 0U;
+        __Runtime_wait_io_cycles(&wio_cyc2, &wio_calls2);
+        unsigned long long pc_launch2 = (pc_mid >= pc0) ? (pc_mid - pc0) : 0ULL;
+        double kp = pc_launch2 ? 100.0 * (double)ph[0] / (double)pc_launch2 : 0.0;
+        double bp = pc_launch2 ? 100.0 * (double)ph[1] / (double)pc_launch2 : 0.0;
+        double wp = pc_launch2 ? 100.0 * (double)wio_cyc2 / (double)pc_launch2 : 0.0;
+        double mpv = vec ? ((double)(M / HW_ROWS) * (double)(N / HW_COLS) * (double)K) / (double)vec : 0.0;
+        double tb2 = (double)active + (double)sstall + (double)lstall;
+        double lsp = tb2 ? 100.0 * (double)lstall / tb2 : 0.0;
+        double ssp = tb2 ? 100.0 * (double)sstall / tb2 : 0.0;
+        unsigned long long ph_tot = ph[0] + ph[1] + ph[2] + ph[3] + wio_cyc2;
+        unsigned long long unacct2 = pc_launch2 > ph_tot ? pc_launch2 - ph_tot : 0ULL;
+        printf("\n[PERF] launch_cyc=%llu\n", pc_launch2);
+        printf("[PERF] kload_cyc=%llu kload_pct=%.1f\n", ph[0], kp);
+        printf("[PERF] bdcfg_cyc=%llu bdcfg_pct=%.1f\n", ph[1], bp);
+        printf("[PERF] lockinit_cyc=%llu lockinit_pct=%.1f\n", unacct2,
+               pc_launch2 ? 100.0 * (double)unacct2 / (double)pc_launch2 : 0.0);
+        printf("[PERF] coreen_cyc=%llu coreen_pct=%.1f\n", ph[2],
+               pc_launch2 ? 100.0 * (double)ph[2] / (double)pc_launch2 : 0.0);
+        printf("[PERF] startio_cyc=%llu startio_pct=%.1f\n", ph[3],
+               pc_launch2 ? 100.0 * (double)ph[3] / (double)pc_launch2 : 0.0);
+        printf("[PERF] wait_io_cyc=%llu wait_io_pct=%.1f\n", wio_cyc2, wp);
+        printf("[PERF] core_active=%u core_sstall=%u core_lstall=%u\n", active, sstall, lstall);
+        printf("[PERF] vec_instr=%u macs_per_vec=%.2f\n", vec, mpv);
+        printf("[PERF] lock_stall_pct=%.1f stream_stall_pct=%.1f\n", lsp, ssp);
+        printf("[PERF] result=%s\n", result == 0 ? "PASS" : "FAIL");
+    }
+
+    printf("\n[prof] device_teardown done\n");
+    return result;
+}

--- a/include/aie_timer.h
+++ b/include/aie_timer.h
@@ -22,4 +22,46 @@ static inline void XTime_GetTime(XTime *t) {
 #include "xtime_l.h"
 #endif
 
+#if defined(__aarch64__) && !defined(__AIESIM__)
+static inline unsigned long long __ps_cntvct(void) {
+    unsigned long long v;
+    __asm__ volatile("mrs %0, cntvct_el0" : "=r"(v));
+    return v;
+}
+static inline unsigned long long __ps_cntfrq(void) {
+    unsigned long long v;
+    __asm__ volatile("mrs %0, cntfrq_el0" : "=r"(v));
+    return v;
+}
+#else
+static inline unsigned long long __ps_cntvct(void) { return 0ULL; }
+static inline unsigned long long __ps_cntfrq(void) { return 0ULL; }
+#endif
+
+#if defined(__aarch64__) && !defined(__AIESIM__)
+static inline void __ps_pmccntr_enable(void) {
+    unsigned long long v;
+    __asm__ volatile("mrs %0, pmcr_el0" : "=r"(v));
+    v |= (1ULL << 0) | (1ULL << 2);
+    v &= ~(1ULL << 3);
+    __asm__ volatile("msr pmcr_el0, %0" : : "r"(v));
+    __asm__ volatile("msr pmcntenset_el0, %0" : : "r"(1ULL << 31));
+    __asm__ volatile("isb");
+}
+static inline unsigned long long __ps_pmccntr(void) {
+    unsigned long long v;
+    __asm__ volatile("mrs %0, pmccntr_el0" : "=r"(v));
+    return v;
+}
+static inline unsigned long long __ps_pmcr(void) {
+    unsigned long long v;
+    __asm__ volatile("mrs %0, pmcr_el0" : "=r"(v));
+    return v;
+}
+#else
+static inline void __ps_pmccntr_enable(void) {}
+static inline unsigned long long __ps_pmccntr(void) { return 0ULL; }
+static inline unsigned long long __ps_pmcr(void) { return 0ULL; }
+#endif
+
 #endif /* AIE_TIMER_H */

--- a/script/aiehlc.sh
+++ b/script/aiehlc.sh
@@ -20,7 +20,9 @@ run_cmd() {
 }
 
 usage() {
-    echo "Usage: $0 --runtime-source-file <path> --aie-version <version> [--kernel-count <count>] [--kernel <source> [<directory>]] [--aielib-only] [--prettydebug] [-gdb]"
+    echo "Usage: $0 --runtime-source-file <path> --aie-version <version> [--kernel-count <count>] [--kernel <source> [<directory>]] [--aielib-only] [--prettydebug] [-gdb] [--profiling] [--skip-bss]"
+    echo "  --profiling   build the host with the PMU profiling layer (-DAIEHLC_PROFILING=1)"
+    echo "  --skip-bss    skip .bss zero-init on kernel load (-DAIEHLC_SKIP_BSS_DEFAULT=1)"
     return 1
 }
 
@@ -158,6 +160,10 @@ USE_LOCAL_AIERT_BSP=0
 PRETTY_DEBUG=0
 SIM_TILES=""
 GDB_MODE=0
+# Reset every run: this script is sourced, so a flag from a previous invocation
+# in the same shell would otherwise persist.
+PROFILING=0
+SKIP_BSS=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -help)
@@ -202,6 +208,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         -gdb|--gdb)
             GDB_MODE=1
+            shift
+            ;;
+        --profiling)
+            PROFILING=1
+            shift
+            ;;
+        --skip-bss)
+            SKIP_BSS=1
             shift
             ;;
         *)
@@ -474,8 +488,13 @@ if [ -f "${HOST_BUILD_DIR}/worklocal/host.cc" ]; then
     done
 
     # Run hostcompile.sh with WORKLOCAL_DIR pointing at aout/worklocal.
+    hc_extra_defs="${EXTRA_DEFS:-}"
+    if [ "${SKIP_BSS}" -eq 1 ]; then
+        hc_extra_defs="${hc_extra_defs} -DAIEHLC_SKIP_BSS_DEFAULT=1"
+    fi
     WORKLOCAL_DIR="${WORKLOCAL_DIR}" AIE_VERSION="${aie_version}" PLATFORM="${platform}" \
         SIM_TILES="${SIM_TILES:-}" \
+        AIEHLC_PROFILING="${PROFILING}" EXTRA_DEFS="${hc_extra_defs}" \
         bash "${AIEHLC_DIR}/script/hostcompile.sh"
     TILING_RC=$?
     if [ $TILING_RC -ne 0 ]; then

--- a/script/hostcompile.sh
+++ b/script/hostcompile.sh
@@ -264,7 +264,11 @@ if [ -d "${XAIE_INCLUDE}" ]; then
 fi
 # User headers are copied to worklocal/ by aiehlc alongside host.cc
 INCLUDE_OPTS="${INCLUDE_OPTS} -I${WORKLOCAL_DIR}"
-DEFS="-DAIE_GEN=${aie_version}"
+DEFS="-DAIE_GEN=${aie_version} ${EXTRA_DEFS:-}"
+if [ "${AIEHLC_PROFILING:-0}" != "0" ]; then
+    DEFS="${DEFS} -DAIEHLC_PROFILING=1"
+    echo "[hostcompile] profiling runtime layer ENABLED (-DAIEHLC_PROFILING=1)"
+fi
 
 mkdir -p "${BUILD_DIR}"
 cd "${BUILD_DIR}"

--- a/script/test/appvek385.py
+++ b/script/test/appvek385.py
@@ -205,6 +205,12 @@ def console_reader(child, output_queue, stop_event):
             if output:
                 buffer += output
                 output_queue.put(output)
+                if "telnet>" in output:
+                    output_queue.put("[console_reader] telnet escape detected — resuming session\n")
+                    try:
+                        child.send("\r")
+                    except Exception:
+                        pass
         except pexpect.TIMEOUT:
             # No data available, continue polling
             continue
@@ -301,22 +307,30 @@ def setup_first_connection():
     index = child.expect([r'xsdb%', r'command not found', r'Unrecognized', pexpect.TIMEOUT], timeout=15)
 
     if index != 0:
-        print("[Connection 1] xsdb not found, trying alternative path...")
+        print("[Connection 1] xsdb not found / timed-out, exiting and trying alternative path...")
+        child.sendline("exit")
+        try:
+            child.expect(r'Systest[#>]', timeout=15)
+        except pexpect.TIMEOUT:
+            child.sendcontrol('c')
+            time.sleep(1)
+            child.sendline("exit")
+            child.expect(r'Systest[#>]', timeout=15)
         child.sendline(XSDB_ALT_PATH)
         child.expect(r'xsdb%', timeout=60)
-    
+
     print("[Connection 1] In xsdb, connecting...")
-    
+
     # Step 7: Connect
     child.sendline("conn")
     child.expect(r'xsdb%', timeout=60)
     print("[Connection 1] Connected, targeting device 1...")
-    
+
     # Step 8: Target 1
     child.sendline("tar 1")
     child.expect(r'xsdb%', timeout=60)
-    print("[Connection 1] Programming Palboard.BIN...")
-    
+    print("[Connection 1] Programming PDI...")
+
     # Step 9: Program device – detect PLM stall and abort early
     child.sendline(f"device program {VEK385PDI}")
     index = child.expect([r'xsdb%', r'PLM stalled'], timeout=120)
@@ -324,20 +338,25 @@ def setup_first_connection():
         # Consume the rest of the error output up to the prompt
         child.expect(r'xsdb%', timeout=60)
         raise RuntimeError(
-            "PLM stalled during BOOT.BIN programming. "
+            "PLM stalled during PDI programming. "
             "The board may need a power cycle. Run 'plm log' for details."
         )
-    time.sleep(5)  # allow PLM to fully initialise before continuing
-    print("[Connection 1] Device programmed, targeting device 20...")
-    
+    print("[Connection 1] PDI programmed, waiting for PS POR release...")
+    time.sleep(15)  # allow PLM to fully initialise before continuing
+    print("[Connection 1] Targeting APU core (Cortex-A78AE #0.0)...")
+
     # Step 10: Target 20
     child.sendline("tar 20")
-    child.expect(r'xsdb%', timeout=60)
+    child.expect(r'xsdb%', timeout=30)
     print("[Connection 1] Resetting processor...")
-    
+
     # Step 11: Reset processor
-    child.sendline("rst -proc")
+    child.sendline("tar 18")
+    child.expect(r'xsdb%', timeout=30)
+    child.sendline("rst -cores")
     child.expect(r'xsdb%', timeout=60)
+    child.sendline("tar 20")
+    child.expect(r'xsdb%', timeout=30)
 
     # Drain any stale xsdb% prompts left in the buffer.
     # xsdb sometimes emits double prompts after rst -proc; if the second
@@ -365,19 +384,18 @@ def setup_second_connection():
     
     # Wait for shell prompt
     child.expect([r'\$\s*$', r'#\s*$', r'>\s*$'], timeout=60)
-    #print("[Connection 2] Connected, starting systest...")
-    
+    print("[Connection 2] Connected, starting systest...")
+
     # Step 2: Run systest
-    #child.sendline("/opt/systest/common/bin/systest-client")
-    #child.expect(r'Systest[#>]', timeout=60)
-    #print("[Connection 2] In systest, connecting to com0...")
-    
+    child.sendline("/opt/systest/common/bin/systest-client")
+    child.expect(r'Systest[#>]', timeout=60)
+    print("[Connection 2] In systest, connecting to com3...")
+
     # Step 3: Connect to com0 (no output until ELF runs on first connection)
-    #child.sendline("connect com0")
-    child.sendline("telnet 10.10.71.1 4001")
-    child.expect(r'Versal PS UART0', timeout=60)
-    print("[Connection 2] Connected to com0, listening for output...")
-    
+    child.sendline("connect com3")
+    child.expect(r'Connecting to device com3.*escape', timeout=60)
+    print("[Connection 2] Connected to com3, listening for output...")
+
     return child
 
 
@@ -491,7 +509,7 @@ Examples:
     parser.add_argument(
         "-y", "--yes",
         action="store_true",
-        default=False,
+        default=True,
         help="Non-interactive mode: auto-confirm all prompts"
     )
     parser.add_argument(

--- a/src/llvm/aiehlc.cc
+++ b/src/llvm/aiehlc.cc
@@ -3183,10 +3183,9 @@ class AieDebugLevelPragmaHandler : public clang::PragmaHandler {
     void HandlePragma(clang::Preprocessor &PP, clang::PragmaIntroducer Introducer, clang::Token &FirstToken) override {
         // Known flag macros (must match aie_runtime.h definitions)
         static const std::unordered_map<std::string, int> knownFlags = {
-            {"AIE_DEBUG_FLAG_DISABLE_MULTID_DIM_DMA", 1 << 4},
-            {"AIE_DEBUG_FLAG_DISABLE_PARTITIONTEARDOWN", 1 << 5},
-            {"AIE_DMA_ISSUE_COUNT", 1 << 7},
-            {"AIE_DEBUG_LOG", 1 << 9},
+            {"AIE_DEBUG_FLAG_DISABLE_MULTID_DIM_DMA", 1 << 4}, {"AIE_DEBUG_FLAG_DISABLE_PARTITIONTEARDOWN", 1 << 5},
+            {"AIE_DEBUG_FLAG_MM2SBDFINISH_COUNTER", 1 << 6},   {"AIE_DMA_ISSUE_COUNT", 1 << 7},
+            {"AIE_DEBUG_FLAG_CORE_PERF_COUNTER", 1 << 8},      {"AIE_DEBUG_LOG", 1 << 9},
         };
 
         clang::Token Tok;

--- a/src/mlir/mlirfront/tilinglinalg/pass/passblueprinttoschedule/helper/flowtransfer_host.cpp
+++ b/src/mlir/mlirfront/tilinglinalg/pass/passblueprinttoschedule/helper/flowtransfer_host.cpp
@@ -1163,10 +1163,6 @@ void FlowTransferConversion::emitScheduleStraightLine(FlowLoweringCtx &c) const 
                          << "repeatCount " << repeatCount << " -> 1\n";
         repeatCount = 1;
     }
-    auto startIoOp = rewriter.create<dfschedule::StartIoOp>(
-        loc, dfschedule::EventType::get(rewriter.getContext()), c.createIoOp.getIoHandle(), c.getBdIdOp.getBdId(),
-        rewriter.getI32IntegerAttr(c.flowIndex), rewriter.getI32IntegerAttr(repeatCount));
-
     auto loadKernelGroupOp = rewriter.create<dfschedule::LoadKernelGroupOp>(
         loc, dfschedule::KernelGroupType::get(rewriter.getContext()), c.coreTiles, rewriter.getArrayAttr(c.calleeAttrs),
         rewriter.getArrayAttr(c.computeKernelAttrs), nullptr, rewriter.getArrayAttr(c.kernelConfigSymbols));
@@ -1175,6 +1171,8 @@ void FlowTransferConversion::emitScheduleStraightLine(FlowLoweringCtx &c) const 
         loc, dfschedule::EventType::get(rewriter.getContext()), loadKernelGroupOp.getKernelGroup());
 
     // Emit deferred core StartIoOp calls AFTER kernel load/launch
+    llvm::errs() << "[emitScheduleStraightLine] flowIdx=" << c.flowIndex << " shimIsSender=" << c.shimIsSender
+                 << " deferredCoreStartIos.size()=" << c.deferredCoreStartIos.size() << "\n";
     SmallVector<Value> coreStartIoEvents;
     for (auto &deferred : c.deferredCoreStartIos) {
         auto coreStartIo = rewriter.create<dfschedule::StartIoOp>(
@@ -1182,6 +1180,10 @@ void FlowTransferConversion::emitScheduleStraightLine(FlowLoweringCtx &c) const 
             rewriter.getI32IntegerAttr(deferred.flowIdx), rewriter.getI32IntegerAttr(deferred.repeatCount));
         coreStartIoEvents.push_back(coreStartIo.getEvent());
     }
+
+    auto startIoOp = rewriter.create<dfschedule::StartIoOp>(
+        loc, dfschedule::EventType::get(rewriter.getContext()), c.createIoOp.getIoHandle(), c.getBdIdOp.getBdId(),
+        rewriter.getI32IntegerAttr(c.flowIndex), rewriter.getI32IntegerAttr(repeatCount));
 
     // Determine whether to bypass input sending IO wait.
     bool bypassInputIoWait = false;

--- a/src/mlir/mlirfront/tilinglinalg/pass/passblueprinttoschedule/helper/flowtransfer_kernel.cpp
+++ b/src/mlir/mlirfront/tilinglinalg/pass/passblueprinttoschedule/helper/flowtransfer_kernel.cpp
@@ -381,9 +381,14 @@ LogicalResult FlowTransferConversion::emitCoreBufferDma(FlowLoweringCtx &c, Core
 
     // --- Core tile ping-pong DMA BD configuration ---
     // Look up per-tile data slice from slice_symbols (maps 1:1 to tiles)
+    llvm::errs() << "[DeferredStartIo] emitCoreBufferDma: flowIdx=" << c.flowIndex << " tileIdx=" << c.tileIndex
+                 << " sliceSymbolsOpt=" << (c.sliceSymbolsOpt ? "yes" : "null")
+                 << " sliceSize=" << (c.sliceSymbolsOpt ? (int)c.sliceSymbolsOpt->size() : -1)
+                 << " flowRootMemref=" << (c.flowRootMemref ? "valid" : "null") << "\n";
     if (c.sliceSymbolsOpt && c.tileIndex < (int)c.sliceSymbolsOpt->size()) {
         auto sliceSymRef = cast<SymbolRefAttr>((*c.sliceSymbolsOpt)[c.tileIndex]);
         auto dataSliceOp = lookupDataSlice(op.getOperation(), sliceSymRef);
+        llvm::errs() << "[DeferredStartIo] dataSliceOp=" << (dataSliceOp ? "found" : "null") << "\n";
         if (dataSliceOp) {
             Value perTileTensor = dataSliceOp.getTensorSlice();
             Type perTileType = perTileTensor.getType();
@@ -391,6 +396,7 @@ LogicalResult FlowTransferConversion::emitCoreBufferDma(FlowLoweringCtx &c, Core
 
             // Trace back to tensor.extract_slice to get per-tile offsets/sizes
             auto tileExtractSlice = perTileTensor.getDefiningOp<tensor::ExtractSliceOp>();
+            llvm::errs() << "[DeferredStartIo] tileExtractSlice=" << (tileExtractSlice ? "yes" : "null") << "\n";
 
             int64_t perTileTotalSize = t.perTileSize / t.elementSizeBytes;
             (void)perTileTotalSize;
@@ -541,6 +547,8 @@ LogicalResult FlowTransferConversion::emitCoreBufferDma(FlowLoweringCtx &c, Core
                 // so the DMA hardware automatically re-arms via the chain.
                 // repeat=1 is sufficient; the BD chain does the work.
                 int32_t coreRepeat = 1;
+                llvm::errs() << "[DeferredStartIo] PUSH deferredCoreStartIos flowIdx=" << c.flowIndex
+                             << " tileIdx=" << c.tileIndex << " total=" << (c.deferredCoreStartIos.size() + 1) << "\n";
                 c.deferredCoreStartIos.push_back(
                     {coreCreateIoOp.getIoHandle(), coreBdIdOp.getBdId(), c.flowIndex, coreRepeat});
             } // end if (passState && ...)

--- a/src/mlir/mlirfront/tilinglinalg/pass/passdfscheduletoapi/passdfscheduletoapi.cpp
+++ b/src/mlir/mlirfront/tilinglinalg/pass/passdfscheduletoapi/passdfscheduletoapi.cpp
@@ -157,6 +157,7 @@ struct ConversionState {
 
     // Track (col,row,lock_id) tuples that have already had XAie_LockSetValue emitted
     std::set<std::tuple<int32_t, int32_t, int32_t>> initializedLocks;
+    std::vector<std::pair<std::string, std::string>> pendingLockInits;
 
     // Debug snapshot data (populated when enableDebug is true)
     SmallVector<IoDebugInfo> debugIos;
@@ -1545,15 +1546,14 @@ struct ConfigDmaBdInnerPattern : public OpConversionPattern<dfschedule::ConfigDm
                                 "/* Lock init: tile(" + std::to_string(tileCol) + "," + std::to_string(tileRow) +
                                 ") lock=" + std::to_string(kernelAcquireLock) +
                                 " init_value=" + std::to_string(lockInitValue) + " (kernel output acquire) */";
-                            rewriter.create<emitc::VerbatimOp>(loc, lockComment);
                             std::string lockSetCall = "XAie_LockSetValue(dev, XAie_TileLoc(" + std::to_string(tileCol) +
                                                       ", " + std::to_string(tileRow) + "), XAie_LockInit(" +
                                                       std::to_string(kernelAcquireLock) + ", " +
                                                       std::to_string(lockInitValue) + "));";
-                            rewriter.create<emitc::VerbatimOp>(loc, lockSetCall);
-                            llvm::errs() << "  Emitted XAie_LockSetValue for tile(" << tileCol << "," << tileRow
+                            state.pendingLockInits.emplace_back(lockComment, lockSetCall);
+                            llvm::errs() << "  Deferred XAie_LockSetValue for tile(" << tileCol << "," << tileRow
                                          << ") lock=" << kernelAcquireLock << " init=" << lockInitValue
-                                         << " (kernel output acquire)\n";
+                                         << " (kernel output acquire) — will emit before launch\n";
                         }
                         // DMA acquire lock (lock 1) init = 0 (default, no explicit init needed)
                         llvm::errs() << "  Output flow: DMA acquire lock " << acquireLockId
@@ -1564,14 +1564,14 @@ struct ConfigDmaBdInnerPattern : public OpConversionPattern<dfschedule::ConfigDm
                         std::string lockComment = "/* Lock init: tile(" + std::to_string(tileCol) + "," +
                                                   std::to_string(tileRow) + ") lock=" + std::to_string(acquireLockId) +
                                                   " init_value=" + std::to_string(initValue) + " */";
-                        rewriter.create<emitc::VerbatimOp>(loc, lockComment);
                         std::string lockSetCall = "XAie_LockSetValue(dev, XAie_TileLoc(" + std::to_string(tileCol) +
                                                   ", " + std::to_string(tileRow) + "), XAie_LockInit(" +
                                                   std::to_string(acquireLockId) + ", " + std::to_string(initValue) +
                                                   "));";
-                        rewriter.create<emitc::VerbatimOp>(loc, lockSetCall);
-                        llvm::errs() << "  ✓ Emitted XAie_LockSetValue for tile(" << tileCol << "," << tileRow
-                                     << ") lock=" << acquireLockId << " init=" << initValue << "\n";
+                        state.pendingLockInits.emplace_back(lockComment, lockSetCall);
+                        llvm::errs() << "  Deferred XAie_LockSetValue for tile(" << tileCol << "," << tileRow
+                                     << ") lock=" << acquireLockId << " init=" << initValue
+                                     << " — will emit before launch\n";
                     }
                 }
             }
@@ -2091,8 +2091,19 @@ struct LaunchKernelGroupInnerPattern : public OpConversionPattern<dfschedule::La
         Value kernelGroup = adaptor.getKernelGroup();
         
         llvm::errs() << "  Kernel Group type: " << kernelGroup.getType() << "\n";
-        //rewriter.eraseOp(op);
-        //return success();
+        // rewriter.eraseOp(op);
+        // return success();
+        if (!state.pendingLockInits.empty()) {
+            rewriter.create<emitc::VerbatimOp>(loc,
+                                               "/* Lock inits — must precede kernel launch to avoid contention */");
+            for (auto &[comment, call] : state.pendingLockInits) {
+                rewriter.create<emitc::VerbatimOp>(loc, comment);
+                rewriter.create<emitc::VerbatimOp>(loc, call);
+            }
+            llvm::errs() << "  Flushed " << state.pendingLockInits.size() << " lock inits before launch_kernel_group\n";
+            state.pendingLockInits.clear();
+        }
+
         // Create comment
         rewriter.create<emitc::VerbatimOp>(loc, "/* Launch Kernel Group */");
 
@@ -3281,7 +3292,64 @@ void DfscheduleToApiPass::runOnOperation() {
         llvm::errs() << "[Pass] Found declare_data #" << declareDataCount << " at " << op->getLoc() << "\n";
     });
     llvm::errs() << "[Pass] Total declare_data ops: " << declareDataCount << "\n";
-    
+
+    {
+        std::set<std::tuple<int32_t, int32_t, int32_t>> preScannedLocks;
+        moduleOp->walk([&](dfschedule::ConfigDmaBdOp bdOp) {
+            int32_t acquireLockId = static_cast<int32_t>(bdOp.getAcquireLockId());
+            int32_t acquireLockVal = static_cast<int32_t>(bdOp.getAcquireLockVal());
+            int32_t releaseLockId = static_cast<int32_t>(bdOp.getReleaseLockId());
+            if (acquireLockId < 0 || acquireLockVal == 0)
+                return;
+            auto declareTileOp = bdOp.getTile().getDefiningOp<dfschedule::DeclareTileOp>();
+            if (!declareTileOp)
+                return;
+            int32_t tileCol = declareTileOp.getCol();
+            int32_t tileRow = declareTileOp.getRow();
+
+            bool isOutput = false;
+            SmallVector<Operation *, 4> worklist;
+            for (auto *user : bdOp.getResult().getUsers())
+                worklist.push_back(user);
+            while (!worklist.empty()) {
+                auto *u = worklist.pop_back_val();
+                if (auto createIoOp = dyn_cast<dfschedule::ConfigCreateIoOp>(u)) {
+                    if (createIoOp.getDirection().str() == "MM2S")
+                        isOutput = true;
+                    break;
+                }
+                if (isa<dfschedule::ConfigDmaBdOp>(u))
+                    for (auto *uu : u->getResults().front().getUsers())
+                        worklist.push_back(uu);
+            }
+
+            int32_t nextBdVal = static_cast<int32_t>(bdOp.getNextBd());
+            bool isSingleBuffer = (nextBdVal == -1) && !bdOp.getLinkedBd();
+            int32_t lockInitValue = isSingleBuffer ? 1 : 2;
+
+            auto emitLock = [&](int32_t lockId, int32_t initVal, const std::string &note) {
+                auto key = std::make_tuple(tileCol, tileRow, lockId);
+                if (preScannedLocks.insert(key).second) {
+                    std::string comment = "/* Lock init: tile(" + std::to_string(tileCol) + "," +
+                                          std::to_string(tileRow) + ") lock=" + std::to_string(lockId) +
+                                          " init_value=" + std::to_string(initVal) + " " + note + " */";
+                    std::string call = "XAie_LockSetValue(dev, XAie_TileLoc(" + std::to_string(tileCol) + ", " +
+                                       std::to_string(tileRow) + "), XAie_LockInit(" + std::to_string(lockId) + ", " +
+                                       std::to_string(initVal) + "));";
+                    state.pendingLockInits.emplace_back(comment, call);
+                }
+            };
+
+            if (isOutput) {
+                emitLock(releaseLockId, lockInitValue, "(kernel output acquire)");
+            } else {
+                emitLock(acquireLockId, lockInitValue, "");
+            }
+        });
+        llvm::errs() << "[Pass] Pre-scan: collected " << state.pendingLockInits.size()
+                     << " lock inits to emit before launch_kernel_group\n";
+    }
+
     if (failed(applyPartialConversion(moduleOp, innerTarget, frozenInnerPatterns))) {
         llvm::errs() << "[Pass] Warning: Some inner ops not converted\n";
     }

--- a/src/mlir/mlirfront/tilinglinalg/pass/passdmaphoptodfscheblueprint/passdmaphoptodfscheblueprint.cpp
+++ b/src/mlir/mlirfront/tilinglinalg/pass/passdmaphoptodfscheblueprint/passdmaphoptodfscheblueprint.cpp
@@ -1022,7 +1022,7 @@ struct PushOpConversion : public OpConversionPattern<dmaphop::push> {
                                     SmallVector<int32_t> strides = {
                                         static_cast<int32_t>(1 * wordBytes),       // D0: 4 bytes
                                         static_cast<int32_t>(fullK_w * wordBytes), // D1: fullK bytes
-                                        static_cast<int32_t>(effectiveK)           // D2: effectiveK bytes
+                                        static_cast<int32_t>(effK_w * wordBytes)   // D2: effectiveK bytes
                                     };
                                     SmallVector<int32_t> wraps = {
                                         static_cast<int32_t>(effK_w),     // D0: effectiveK/4

--- a/src/mlir/mlirfront/tilinglinalg/pass/passschedulecanonicalize/passschedulecanonicalize.cpp
+++ b/src/mlir/mlirfront/tilinglinalg/pass/passschedulecanonicalize/passschedulecanonicalize.cpp
@@ -468,25 +468,24 @@ static void buildHostBlockByCloning(func::FuncOp mainFunc, ModuleOp moduleOp) {
                                                                         loadOp.getKernelGroup());
         launchEvent = launchOp.getEvent();
 
-        // Move only CORE-tile StartIoOp ops to AFTER the merged LaunchKernelGroupOp.
-        // ELF loading (triggered by LoadKernelGroupOp) zeroes BSS in core
-        // tile memory.  If core S2MM DMA StartIoOps fire before the ELF load,
-        // DMA-written data gets overwritten with zeros.  By placing core StartIoOps
-        // after the launch, the ELF is fully loaded before DMAs start writing.
-        // Shim StartIoOps remain in their original position (before load_kernel_group)
-        // so that shim DMA channels are armed first.
         SmallVector<Operation *> coreStartIoOps;
+        SmallVector<Operation *> shimSenderStartIoOps;
         for (Operation &op : *hostBody) {
             if (auto startIo = dyn_cast<dfschedule::StartIoOp>(&op)) {
-                // Trace: StartIoOp → io_handle (ConfigCreateIoOp) → tile (DeclareTileOp)
                 bool isShim = false;
+                bool isMM2S = false;
                 if (auto createIo = startIo.getIoHandle().getDefiningOp<dfschedule::ConfigCreateIoOp>()) {
                     if (auto declareTile = createIo.getTile().getDefiningOp<dfschedule::DeclareTileOp>()) {
                         isShim = (declareTile.getRow() == 0);
                     }
+                    if (auto dirAttr = createIo->getAttrOfType<mlir::StringAttr>("direction"))
+                        isMM2S = (dirAttr.getValue() == "MM2S");
                 }
-                if (!isShim)
+                if (!isShim) {
                     coreStartIoOps.push_back(&op);
+                } else if (isMM2S) {
+                    shimSenderStartIoOps.push_back(&op);
+                }
             }
         }
         Operation *insertAfter = launchOp;
@@ -494,6 +493,12 @@ static void buildHostBlockByCloning(func::FuncOp mainFunc, ModuleOp moduleOp) {
             op->moveAfter(insertAfter);
             insertAfter = op;
         }
+        for (Operation *op : shimSenderStartIoOps) {
+            op->moveAfter(insertAfter);
+            insertAfter = op;
+        }
+        llvm::errs() << "[ScheduleCanonicalize] StartIo ordering: " << coreStartIoOps.size() << " core, "
+                     << shimSenderStartIoOps.size() << " shim-MM2S moved after launch\n";
     }
 
     // Prepend launch event so wait covers it first.

--- a/src/mlir/mlirfront/tilinglinalg/pass/routingimplement/hw/ResourceManager.cpp
+++ b/src/mlir/mlirfront/tilinglinalg/pass/routingimplement/hw/ResourceManager.cpp
@@ -293,17 +293,22 @@ std::shared_ptr<DataIO> ResourceMgr::createDataIO(IOType tp, int r, int c, DMADI
     return dataioptr;
 }
 // ---------- linkAvailable ----------
-//link a to link b means same port number of A slave and B master should both exist
 bool ResourceMgr::linkAvailable(Point a, Point b, int& portIdx) const {
     PortDirection dir=getDir(a,b), odir=opposite(dir);
-    const auto& va = tile(a.r,a.c).bank(dir).slave;
-    const auto& vb = tile(b.r,b.c).bank(odir).master;
-    int lim = std::min<int>(va.size(), vb.size());
-    std::cout << "[linkAvailable] (" << a.r << "," << a.c << ")->(" << b.r << "," << b.c << ") dir=" << (int)dir
-              << " va.size=" << va.size() << " vb.size=" << vb.size() << " lim=" << lim << std::endl;
+    const auto &va_slave = tile(a.r, a.c).bank(dir).slave;
+    const auto &vb_master = tile(b.r, b.c).bank(odir).master;
+    const auto &va_master = tile(a.r, a.c).bank(dir).master;
+    const auto &vb_slave = tile(b.r, b.c).bank(odir).slave;
+    int lim = std::min<int>(va_slave.size(), vb_master.size());
     for (int ch = 0; ch < lim; ++ch) {
-        std::cout << "  ch=" << ch << " va[ch].used=" << va[ch].used << " vb[ch].used=" << vb[ch].used << std::endl;
-        if(!va[ch].used && !vb[ch].used){ portIdx=ch; return true; }
+        if (va_slave[ch].used || vb_master[ch].used)
+            continue;
+        bool a_reverse_used = (ch < (int)va_master.size()) && va_master[ch].used;
+        bool b_reverse_used = (ch < (int)vb_slave.size()) && vb_slave[ch].used;
+        if (a_reverse_used || b_reverse_used)
+            continue;
+        portIdx = ch;
+        return true;
     }
     return false;
 }

--- a/src/mlir/runtime/aie_runtime.c
+++ b/src/mlir/runtime/aie_runtime.c
@@ -46,6 +46,218 @@ XAie_DevInst *g_DevInst = NULL;
 
 XAie_DevInst *getOrCreateDeviceInstance(void) { return g_DevInst; }
 
+#ifndef AIEHLC_PROFILING
+#define AIEHLC_PROFILING 0
+#endif
+
+#if AIEHLC_PROFILING && defined(__aarch64__) && !defined(__AIESIM__)
+static inline unsigned long long __rt_pmccntr(void) {
+    unsigned long long v;
+    __asm__ volatile("mrs %0, pmccntr_el0" : "=r"(v));
+    return v;
+}
+#else
+static inline unsigned long long __rt_pmccntr(void) { return 0ULL; }
+#endif
+
+#if AIEHLC_PROFILING
+#define RT_PROF_TIC() __rt_pmccntr()
+#define RT_PROF_ADD(cyc, n, t0)                                                                                        \
+    do {                                                                                                               \
+        (cyc) += (__rt_pmccntr() - (t0));                                                                              \
+        (n)++;                                                                                                         \
+    } while (0)
+#define RT_PROF_PHASE(ph, t0) __rt_ph_add((ph), (t0))
+#define RT_PROF_INC(v)                                                                                                 \
+    do {                                                                                                               \
+        (v)++;                                                                                                         \
+    } while (0)
+#else
+#define RT_PROF_TIC() 0ULL
+#define RT_PROF_ADD(cyc, n, t0)                                                                                        \
+    do {                                                                                                               \
+        (void)(t0);                                                                                                    \
+    } while (0)
+#define RT_PROF_PHASE(ph, t0)                                                                                          \
+    do {                                                                                                               \
+        (void)(t0);                                                                                                    \
+    } while (0)
+#define RT_PROF_INC(v)                                                                                                 \
+    do {                                                                                                               \
+    } while (0)
+#endif
+
+static unsigned long long g_wait_io_cycles = 0ULL;
+static unsigned int g_wait_io_calls = 0U;
+static unsigned long long g_wait_io_iters = 0ULL;
+
+enum { PH_KLOAD = 0, PH_BDCFG = 1, PH_COREEN = 2, PH_STARTIO = 3, PH_N = 4 };
+static unsigned long long g_ph_cyc[PH_N] = {0, 0, 0, 0};
+static unsigned int g_ph_calls[PH_N] = {0, 0, 0, 0};
+
+static unsigned long long g_bd_init_cyc = 0ULL, g_bd_write_cyc = 0ULL;
+static unsigned int g_bd_init_n = 0U, g_bd_write_n = 0U;
+static unsigned long long g_bd_mid_cyc = 0ULL, g_bd_tail_cyc = 0ULL;
+static unsigned int g_bd_mid_n = 0U, g_bd_tail_n = 0U;
+static unsigned long long g_bd_gtt_cyc = 0ULL, g_bd_saddr_cyc = 0ULL, g_bd_en_cyc = 0ULL;
+static unsigned int g_bd_gtt_n = 0U, g_bd_saddr_n = 0U, g_bd_en_n = 0U;
+static unsigned long long g_kl_elf_cyc = 0ULL, g_kl_rst_cyc = 0ULL;
+static unsigned int g_kl_elf_n = 0U, g_kl_rst_n = 0U;
+
+#if AIEHLC_PROFILING
+static inline void __rt_ph_add(int ph, unsigned long long t0) {
+    g_ph_cyc[ph] += (__rt_pmccntr() - t0);
+    g_ph_calls[ph]++;
+}
+#endif
+
+void __Runtime_wait_io_cycles(unsigned long long *cycles, unsigned int *calls) {
+    if (cycles)
+        *cycles = g_wait_io_cycles;
+    if (calls)
+        *calls = g_wait_io_calls;
+}
+void __Runtime_wait_io_iters(unsigned long long *iters) {
+    if (iters)
+        *iters = g_wait_io_iters;
+}
+void __Runtime_phase_cycles(unsigned long long *cyc, unsigned int *calls) {
+    for (int i = 0; i < PH_N; i++) {
+        if (cyc)
+            cyc[i] = g_ph_cyc[i];
+        if (calls)
+            calls[i] = g_ph_calls[i];
+    }
+}
+void __Runtime_bd_subphase_cycles(unsigned long long *init_cyc, unsigned int *init_n, unsigned long long *write_cyc,
+                                  unsigned int *write_n) {
+    if (init_cyc)
+        *init_cyc = g_bd_init_cyc;
+    if (init_n)
+        *init_n = g_bd_init_n;
+    if (write_cyc)
+        *write_cyc = g_bd_write_cyc;
+    if (write_n)
+        *write_n = g_bd_write_n;
+}
+void __Runtime_bd_midtail_cycles(unsigned long long *mid_cyc, unsigned int *mid_n, unsigned long long *tail_cyc,
+                                 unsigned int *tail_n) {
+    if (mid_cyc)
+        *mid_cyc = g_bd_mid_cyc;
+    if (mid_n)
+        *mid_n = g_bd_mid_n;
+    if (tail_cyc)
+        *tail_cyc = g_bd_tail_cyc;
+    if (tail_n)
+        *tail_n = g_bd_tail_n;
+}
+void __Runtime_bd_mid3_cycles(unsigned long long *gtt_cyc, unsigned int *gtt_n, unsigned long long *saddr_cyc,
+                              unsigned int *saddr_n, unsigned long long *en_cyc, unsigned int *en_n) {
+    if (gtt_cyc)
+        *gtt_cyc = g_bd_gtt_cyc;
+    if (gtt_n)
+        *gtt_n = g_bd_gtt_n;
+    if (saddr_cyc)
+        *saddr_cyc = g_bd_saddr_cyc;
+    if (saddr_n)
+        *saddr_n = g_bd_saddr_n;
+    if (en_cyc)
+        *en_cyc = g_bd_en_cyc;
+    if (en_n)
+        *en_n = g_bd_en_n;
+}
+void __Runtime_kload_split_cycles(unsigned long long *elf_cyc, unsigned int *elf_n, unsigned long long *rst_cyc,
+                                  unsigned int *rst_n) {
+    if (elf_cyc)
+        *elf_cyc = g_kl_elf_cyc;
+    if (elf_n)
+        *elf_n = g_kl_elf_n;
+    if (rst_cyc)
+        *rst_cyc = g_kl_rst_cyc;
+    if (rst_n)
+        *rst_n = g_kl_rst_n;
+}
+
+static int s_core_perf_probe_valid = 0;
+static XAie_LocType s_core_perf_probe_tile;
+static XAie_DevInst *s_core_perf_probe_dev = NULL;
+
+AieRC __Runtime_core_perf_setup(XAie_DevInst *dev, XAie_LocType tile) {
+    AieRC rc;
+    rc = XAie_PerfCounterSet(dev, tile, XAIE_CORE_MOD, 0, 0);
+    if (rc != XAIE_OK)
+        return rc;
+    rc = XAie_PerfCounterControlSet(dev, tile, XAIE_CORE_MOD, 0, XAIE_EVENT_ACTIVE_CORE, XAIE_EVENT_ACTIVE_CORE);
+    if (rc != XAIE_OK)
+        return rc;
+    rc = XAie_PerfCounterSet(dev, tile, XAIE_CORE_MOD, 1, 0);
+    if (rc != XAIE_OK)
+        return rc;
+    rc = XAie_PerfCounterControlSet(dev, tile, XAIE_CORE_MOD, 1, XAIE_EVENT_INSTR_VECTOR_CORE,
+                                    XAIE_EVENT_INSTR_VECTOR_CORE);
+    if (rc != XAIE_OK)
+        return rc;
+    rc = XAie_PerfCounterSet(dev, tile, XAIE_CORE_MOD, 2, 0);
+    if (rc != XAIE_OK)
+        return rc;
+    rc = XAie_PerfCounterControlSet(dev, tile, XAIE_CORE_MOD, 2, XAIE_EVENT_STREAM_STALL_CORE,
+                                    XAIE_EVENT_STREAM_STALL_CORE);
+    if (rc != XAIE_OK)
+        return rc;
+    rc = XAie_PerfCounterSet(dev, tile, XAIE_CORE_MOD, 3, 0);
+    if (rc != XAIE_OK)
+        return rc;
+    rc =
+        XAie_PerfCounterControlSet(dev, tile, XAIE_CORE_MOD, 3, XAIE_EVENT_LOCK_STALL_CORE, XAIE_EVENT_LOCK_STALL_CORE);
+    if (rc != XAIE_OK)
+        return rc;
+    AIEHLC_LOG(printf("[aie_runtime] core_perf_setup OK tile(%u,%u)\n", (unsigned)tile.Col, (unsigned)tile.Row));
+    return XAIE_OK;
+}
+
+int __Runtime_core_perf_probe_valid(void) { return s_core_perf_probe_valid; }
+
+void __Runtime_core_perf_read_probe(uint32_t *active, uint32_t *vec_instr, uint32_t *stream_stall,
+                                    uint32_t *lock_stall) {
+    if (!s_core_perf_probe_valid) {
+        if (active)
+            *active = 0;
+        if (vec_instr)
+            *vec_instr = 0;
+        if (stream_stall)
+            *stream_stall = 0;
+        if (lock_stall)
+            *lock_stall = 0;
+        return;
+    }
+    XAie_LocType tile = s_core_perf_probe_tile;
+    XAie_DevInst *dev = s_core_perf_probe_dev;
+    if (active)
+        XAie_PerfCounterGet(dev, tile, XAIE_CORE_MOD, 0, active);
+    if (vec_instr)
+        XAie_PerfCounterGet(dev, tile, XAIE_CORE_MOD, 1, vec_instr);
+    if (stream_stall)
+        XAie_PerfCounterGet(dev, tile, XAIE_CORE_MOD, 2, stream_stall);
+    if (lock_stall)
+        XAie_PerfCounterGet(dev, tile, XAIE_CORE_MOD, 3, lock_stall);
+}
+
+void __Runtime_perfcnt_read_mm2s_probe(uint32_t *ch0, uint32_t *ch1) {
+    if (!s_core_perf_probe_valid) {
+        if (ch0)
+            *ch0 = 0;
+        if (ch1)
+            *ch1 = 0;
+        return;
+    }
+    XAie_LocType tile = s_core_perf_probe_tile;
+    XAie_DevInst *dev = s_core_perf_probe_dev;
+    if (ch0)
+        __Runtime_perfcnt_read(dev, tile, 0, ch0);
+    if (ch1)
+        __Runtime_perfcnt_read(dev, tile, 1, ch1);
+}
+
 // Global routing instance (kept for legacy path)
 XAie_RoutingInstance *g_RoutingInst = NULL;
 
@@ -571,7 +783,7 @@ XAie_DevInst *__Runtime_explicit_init(void) {
     }
 
 #if AIE_GEN == 5 && !defined(__AIESIM__)
-    // XAie_SetXprodEnable(dev, XAIE_DISABLE);
+    XAie_SetXprodEnable(dev, XAIE_DISABLE);
 #endif
     AieRC RC = XAie_CfgInitialize(dev, &g_Config);
     if (RC != XAIE_OK) {
@@ -614,11 +826,6 @@ XAie_DevInst *__Runtime_explicit_init(void) {
 
     __Runtime_routing_init(dev);
 
-    if (AIE_DEBUG_HAS_FLAG(g_runtime_debug_level, AIE_DEBUG_FLAG_MM2SBDFINISH_COUNTER)) {
-        __Runtime_perfcnt_setup_mm2s_bd_finished_partition(dev, 0, XAIE_NUM_COLS - 1, XAIE_AIE_TILE_ROW_START,
-                                                           XAIE_AIE_TILE_ROW_START + XAIE_AIE_TILE_NUM_ROWS - 1);
-    }
-
     AIEHLC_LOG(printf("[aie_runtime] explicit_init OK dev=%p\n", (void *)dev););
     g_DevInst = dev;
     return dev;
@@ -647,7 +854,7 @@ XAie_DevInst *__Runtime_explicit_init_partition(int startCol, int numCols) {
     }
 
 #if AIE_GEN == 5 && !defined(__AIESIM__)
-    // XAie_SetXprodEnable(dev, XAIE_DISABLE);
+    XAie_SetXprodEnable(dev, XAIE_DISABLE);
 #endif
     RC = XAie_CfgInitialize(dev, &g_Config);
     if (RC != XAIE_OK) {
@@ -710,11 +917,6 @@ XAie_DevInst *__Runtime_explicit_init_partition(int startCol, int numCols) {
     }
     */
     __Runtime_routing_init(dev);
-
-    if (AIE_DEBUG_HAS_FLAG(g_runtime_debug_level, AIE_DEBUG_FLAG_MM2SBDFINISH_COUNTER)) {
-        __Runtime_perfcnt_setup_mm2s_bd_finished_partition(dev, 0, XAIE_NUM_COLS - 1, XAIE_AIE_TILE_ROW_START,
-                                                           XAIE_AIE_TILE_ROW_START + XAIE_AIE_TILE_NUM_ROWS - 1);
-    }
 
     AIEHLC_LOG(printf("[aie_runtime] explicit_init_partition OK startCol=%d numCols=%d dev=%p\n", startCol, numCols,
                       (void *)dev););
@@ -858,6 +1060,7 @@ XAie_DmaDesc __Runtime_dma_bd_config(XAie_DevInst *dev, XAie_LocType tile, void 
                                      int32_t next_bd, int32_t enable_packet, int32_t packet_id, int32_t acquire_lock_id,
                                      int32_t acquire_lock_val, int32_t release_lock_id, int32_t release_lock_val,
                                      int32_t out_of_order_bd_id) {
+    unsigned long long __bd_t0 = RT_PROF_TIC();
     XAie_DmaDesc DmaInst;
     XAie_DmaDescInit(dev, &DmaInst, tile);
     uint8_t tile_type = XAie_GetTileTypefromLoc(dev, tile);
@@ -958,6 +1161,7 @@ XAie_DmaDesc __Runtime_dma_bd_config(XAie_DevInst *dev, XAie_LocType tile, void 
         }
     }
 
+    RT_PROF_PHASE(PH_BDCFG, __bd_t0);
     return DmaInst;
 }
 
@@ -976,6 +1180,7 @@ XAie_DmaDesc __Runtime_dma_bd_config_multidim(XAie_DevInst *dev, XAie_LocType ti
                                               int32_t dim_stride2, int32_t dim_wrap2, int32_t dim_stride3,
                                               int32_t dim_wrap3) {
 
+    unsigned long long __bd_t0 = RT_PROF_TIC();
     XAie_DmaDesc DmaInst;
     XAie_DmaDescInit(dev, &DmaInst, tile);
     uint8_t tile_type = XAie_GetTileTypefromLoc(dev, tile);
@@ -1069,6 +1274,7 @@ XAie_DmaDesc __Runtime_dma_bd_config_multidim(XAie_DevInst *dev, XAie_LocType ti
         e->next_bd = (int8_t)next_bd;
     }
 
+    RT_PROF_PHASE(PH_BDCFG, __bd_t0);
     return DmaInst;
 }
 
@@ -1092,6 +1298,7 @@ XAie_DmaDesc __Runtime_dma_bd_config_multidim_ooo(XAie_DevInst *dev, XAie_LocTyp
                                                   int32_t dim_stride2, int32_t dim_wrap2, int32_t iter_step_size,
                                                   int32_t iter_wrap) {
 
+    unsigned long long __bd_t0 = RT_PROF_TIC();
     XAie_DmaDesc DmaInst;
     XAie_DmaDescInit(dev, &DmaInst, tile);
     uint8_t tile_type = XAie_GetTileTypefromLoc(dev, tile);
@@ -1186,6 +1393,7 @@ XAie_DmaDesc __Runtime_dma_bd_config_multidim_ooo(XAie_DevInst *dev, XAie_LocTyp
         e->next_bd = (int8_t)next_bd;
     }
 
+    RT_PROF_PHASE(PH_BDCFG, __bd_t0);
     return DmaInst;
 }
 
@@ -1268,6 +1476,7 @@ void __Runtime_dma_channel_enable_ooo(XAie_DevInst *dev, XAie_LocType tile, int3
  *         pass it to __Runtime_wait_io/__Runtime_wait to block until completion.
  */
 struct_ioevent __Runtime_startio(XAie_DevInst *dev, struct_io io, int32_t bd_id, int32_t repeat) {
+    unsigned long long __sio_t0 = RT_PROF_TIC();
     struct_ioevent evt;
     evt.io = io;
     evt.timeout_us = 10000;
@@ -1316,6 +1525,7 @@ struct_ioevent __Runtime_startio(XAie_DevInst *dev, struct_io io, int32_t bd_id,
                (unsigned)io.bd_id);
     }
 
+    RT_PROF_PHASE(PH_STARTIO, __sio_t0);
     return evt;
 }
 
@@ -1332,6 +1542,53 @@ struct_ioevent _Runtime_startio_ooo(XAie_DevInst *dev, struct_io io, int32_t bd_
  * Load kernel ELF into tiles
  * Reference: aieml_perf.cc lines 123-125
  */
+#if !defined(__AIESIM__)
+static AieRC __Runtime_load_elf_mem_skip_bss(XAie_DevInst *dev, XAie_LocType loc, const unsigned char *elfmem) {
+    const Elf32_Ehdr *ehdr = (const Elf32_Ehdr *)elfmem;
+    u32 skipped = 0, loaded = 0;
+    for (u32 ph = 0; ph < ehdr->e_phnum; ph++) {
+        const Elf32_Phdr *phdr = (const Elf32_Phdr *)(elfmem + ehdr->e_phoff + (u64)ph * sizeof(Elf32_Phdr));
+        if (phdr->p_type != (u32)PT_LOAD)
+            continue;
+        if (phdr->p_filesz == 0U) {
+            skipped++;
+            continue;
+        }
+        AieRC rc = XAie_LoadElfSection(dev, loc, elfmem + phdr->p_offset, phdr);
+        if (rc != XAIE_OK)
+            return rc;
+        loaded++;
+    }
+    AIEHLC_LOG(printf("[aie_runtime] skip-bss load: %u segs loaded, %u bss segs skipped\n", loaded, skipped));
+    return XAIE_OK;
+}
+#endif
+
+#if !defined(__AIESIM__)
+static int __Runtime_skip_bss_enabled(void) {
+#if defined(AIEHLC_SKIP_BSS_DEFAULT)
+    return (AIEHLC_SKIP_BSS_DEFAULT);
+#else
+    static int s_skip_bss = -1;
+    if (s_skip_bss < 0) {
+        const char *e = getenv("AIEHLC_SKIP_BSS");
+        s_skip_bss = (e && e[0] && e[0] != '0') ? 1 : 0;
+    }
+    return s_skip_bss;
+#endif
+}
+#endif
+
+static void __Runtime_load_kernel_elf(XAie_DevInst *dev, XAie_LocType loc, unsigned char *elfmem) {
+#if !defined(__AIESIM__)
+    if (__Runtime_skip_bss_enabled()) {
+        __Runtime_load_elf_mem_skip_bss(dev, loc, elfmem);
+        return;
+    }
+#endif
+    XAie_LoadElfMem(dev, loc, elfmem);
+}
+
 struct_kernel_group __Runtime_load_kernel_group(XAie_DevInst *dev, XAie_LocType *tiles, int32_t num_tiles,
                                                 unsigned char **elf_buffers) {
     struct_kernel_group kg;
@@ -1352,7 +1609,7 @@ struct_kernel_group __Runtime_load_kernel_group(XAie_DevInst *dev, XAie_LocType 
             // #else
             XAie_CoreDisable(dev, tiles[i]);
             XAie_CoreReset(dev, tiles[i]);
-            XAie_LoadElfMem(dev, tiles[i], elf_buffers[i]);
+            __Runtime_load_kernel_elf(dev, tiles[i], elf_buffers[i]);
             XAie_CoreUnreset(dev, tiles[i]);
             // #endif
         }
@@ -1364,6 +1621,7 @@ struct_kernel_group __Runtime_load_kernel_group(XAie_DevInst *dev, XAie_LocType 
 /** Array-based variant: copies caller-provided tile array into the static buffer
  *  and loads the kernel ELF into each core tile. Supports up to MAX_KERNEL_TILES. */
 struct_kernel_group __Runtime_load_kernel_group_nt(XAie_DevInst *dev, XAie_LocType *tiles, int n) {
+    unsigned long long __kl_t0 = RT_PROF_TIC();
     AIEHLC_LOG(printf("[aie_runtime] load_kernel_group_nt n=%d\n", n););
     if (n > MAX_KERNEL_TILES) {
         printf("[aie_runtime] WARNING: tile count %d exceeds MAX_KERNEL_TILES %d, clamping\n", n, MAX_KERNEL_TILES);
@@ -1385,16 +1643,23 @@ struct_kernel_group __Runtime_load_kernel_group_nt(XAie_DevInst *dev, XAie_LocTy
         //   XAie_LoadElfMem(dev, s_kernel_tiles[i], s_active_kernel_elf);
         //   XAie_CoreUnreset(dev, s_kernel_tiles[i]);
         // #else
+        unsigned long long __kr0 = RT_PROF_TIC();
         XAie_CoreDisable(dev, s_kernel_tiles[i]);
         XAie_CoreReset(dev, s_kernel_tiles[i]);
-        XAie_LoadElfMem(dev, s_kernel_tiles[i], s_active_kernel_elf);
+        RT_PROF_ADD(g_kl_rst_cyc, g_kl_rst_n, __kr0);
+        unsigned long long __ke0 = RT_PROF_TIC();
+        __Runtime_load_kernel_elf(dev, s_kernel_tiles[i], s_active_kernel_elf);
+        RT_PROF_ADD(g_kl_elf_cyc, g_kl_elf_n, __ke0);
+        unsigned long long __ku0 = RT_PROF_TIC();
         XAie_CoreUnreset(dev, s_kernel_tiles[i]);
+        RT_PROF_ADD(g_kl_rst_cyc, g_kl_rst_n, __ku0);
         // #endif
     }
     struct_kernel_group kg;
     kg.tiles = s_kernel_tiles;
     kg.num_tiles = n;
     kg.elf_buffers = NULL;
+    RT_PROF_PHASE(PH_KLOAD, __kl_t0);
     return kg;
 }
 
@@ -1453,7 +1718,35 @@ struct_event __Runtime_launch_kernel_group(XAie_DevInst *dev, struct_kernel_grou
     evt.timeout_us = 100000;
 
     AIEHLC_LOG(printf("[aie_runtime] launch_kernel_group num_tiles=%u\n", (unsigned)kg.num_tiles););
+
+#if AIEHLC_PROFILING
+    if (AIE_DEBUG_HAS_FLAG(g_runtime_debug_level, AIE_DEBUG_FLAG_MM2SBDFINISH_COUNTER)) {
+        for (uint32_t i = 0; i < kg.num_tiles; i++) {
+            if (__Runtime_is_aie_core_tile(kg.tiles[i]))
+                __Runtime_perfcnt_setup_mm2s_bd_finished(dev, kg.tiles[i]);
+        }
+    }
+    if (AIE_DEBUG_HAS_FLAG(g_runtime_debug_level, AIE_DEBUG_FLAG_CORE_PERF_COUNTER)) {
+        int chosen = 0;
+        for (uint32_t i = 0; i < kg.num_tiles; i++) {
+            if (__Runtime_is_aie_core_tile(kg.tiles[i])) {
+                __Runtime_core_perf_setup(dev, kg.tiles[i]);
+                if (!chosen) {
+                    s_core_perf_probe_tile = kg.tiles[i];
+                    s_core_perf_probe_valid = 1;
+                    s_core_perf_probe_dev = dev;
+                    chosen = 1;
+                    AIEHLC_LOG(printf("[aie_runtime] core_perf probe tile=(%u,%u)\n", (unsigned)kg.tiles[i].Col,
+                                      (unsigned)kg.tiles[i].Row));
+                }
+            }
+        }
+    }
+#endif
+
+    unsigned long long __ce_t0 = RT_PROF_TIC();
     __Runtime_core_run(dev, kg.tiles, kg.num_tiles);
+    RT_PROF_PHASE(PH_COREEN, __ce_t0);
 
     return evt;
 }
@@ -1500,25 +1793,23 @@ void __Runtime_wait_event(XAie_DevInst *dev, struct_event event) {
             printf("[aie_runtime] wait_event TIMEOUT after %u iters - continuing to debug snapshot\n", iter);
     }
 #else
-    uint32_t timeout_iters = 100;
-    uint32_t iter = 0;
-    do {
-        allDone = 1;
+    (void)allDone;
+    AIEHLC_LOG(printf("[aie_runtime] wait_event: not polling Core_Done (completion gated on"
+                      " output-DMA drain in wait_io)\n"));
+    if (AIEHLC_LOG_ENABLED()) {
         for (uint32_t i = 0; i < event.num_tiles; i++) {
-            if (!__Runtime_is_aie_core_tile(event.tiles[i])) {
+            if (!__Runtime_is_aie_core_tile(event.tiles[i]))
                 continue;
-            }
-            AieRC RC = XAie_CoreWaitForDone(dev, event.tiles[i], 0);
-            if (RC != XAIE_OK) {
-                allDone = 0;
-            }
+            u32 cs = 0;
+            u8 doneb = 0;
+            u32 pc = 0;
+            AieRC rcs = XAie_CoreGetStatus(dev, event.tiles[i], &cs);
+            XAie_CoreReadDoneBit(dev, event.tiles[i], &doneb);
+            XAie_CoreGetPCValue(dev, event.tiles[i], &pc);
+            printf("[corestat] tile(%u,%u) rc=%d status=0x%08x done=%u pc=0x%08x\n", (unsigned)event.tiles[i].Col,
+                   (unsigned)event.tiles[i].Row, (int)rcs, (unsigned)cs, (unsigned)doneb, (unsigned)pc);
         }
-        iter++;
-    } while (!allDone && iter < timeout_iters);
-    if (allDone)
-        AIEHLC_LOG(printf("[aie_runtime] wait_event done\n"););
-    else
-        printf("[aie_runtime] wait_event TIMEOUT after %u iters - continuing to debug snapshot\n", iter);
+    }
 #endif
 }
 
@@ -1529,6 +1820,7 @@ void __Runtime_wait_event(XAie_DevInst *dev, struct_event event) {
  * Reference: aeg_runtime_api.cpp waitDMAChannelTaskQueue / waitDMAChannelDone
  */
 void __Runtime_wait_io(XAie_DevInst *dev, struct_ioevent io_event) {
+    unsigned long long __wio_t0 = RT_PROF_TIC();
     XAie_LocType tile = io_event.io.tile_loc;
     uint8_t channel = io_event.io.channel_id;
     XAie_DmaDirection dir = io_event.io.direction;
@@ -1558,11 +1850,11 @@ void __Runtime_wait_io(XAie_DevInst *dev, struct_ioevent io_event) {
         }
     }
 #else
-    const uint32_t poll_interval_us = 1000 * 1000;
-    const uint32_t max_iters = 5;
+    const uint32_t max_iters = 50000000U;
     u8 numPendingBDs = 1;
     uint32_t iter = 0;
     while (numPendingBDs > 0) {
+        RT_PROF_INC(g_wait_io_iters);
         AieRC rc = XAie_DmaGetPendingBdCount(dev, tile, channel, dir, &numPendingBDs);
         if (rc != XAIE_OK) {
             printf("[aie_runtime] wait_io ERROR: XAie_DmaGetPendingBdCount "
@@ -1570,19 +1862,10 @@ void __Runtime_wait_io(XAie_DevInst *dev, struct_ioevent io_event) {
                    (int)rc, (unsigned)tile.Col, (unsigned)tile.Row, (unsigned)channel, (int)dir);
             return;
         }
-        if (numPendingBDs > 0) {
-            if (++iter >= max_iters) {
-                printf("[aie_runtime] wait_io TIMEOUT after %u ms "
-                       "tile(%u,%u) ch=%u dir=%d pending=%u\n",
-                       (unsigned)(max_iters * poll_interval_us / 1000), (unsigned)tile.Col, (unsigned)tile.Row,
-                       (unsigned)channel, (int)dir, (unsigned)numPendingBDs);
-                return;
-            } else if (AIEHLC_LOG_ENABLED()) {
-                printf("[aie_runtime] wait_io pending tile(%u,%u) ch=%u dir=%d pending=%u iter=%u\n",
-                       (unsigned)tile.Col, (unsigned)tile.Row, (unsigned)channel, (int)dir, (unsigned)numPendingBDs,
-                       (unsigned)iter);
-            }
-            usleep(poll_interval_us);
+        if (numPendingBDs > 0 && ++iter >= max_iters) {
+            printf("[aie_runtime] wait_io TIMEOUT tile(%u,%u) ch=%u dir=%d pending=%u\n", (unsigned)tile.Col,
+                   (unsigned)tile.Row, (unsigned)channel, (int)dir, (unsigned)numPendingBDs);
+            return;
         }
     }
 #endif
@@ -1610,6 +1893,7 @@ void __Runtime_wait_io(XAie_DevInst *dev, struct_ioevent io_event) {
         }
     }
 #endif
+    RT_PROF_ADD(g_wait_io_cycles, g_wait_io_calls, __wio_t0);
 }
 
 /**

--- a/src/mlir/runtime/aie_runtime.h
+++ b/src/mlir/runtime/aie_runtime.h
@@ -7,6 +7,15 @@
 #define AIE_RUNTIME_H
 
 #include "xaiengine.h"
+#ifndef XAIE_ROUTING_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <aie_codegen_inc/xaie_routing.h>
+#ifdef __cplusplus
+}
+#endif
+#endif
 #include <stdio.h>
 #include <string.h>
 // #include <stdint.h>
@@ -54,6 +63,7 @@ XAie_DevInst *getOrCreateDeviceInstance(void);
 // __Runtime_perfcnt_setup_mm2s_bd_finished_partition(); teardown reads them
 // back. These are the same counters aiegdb.py "dma counter" reads (0x11020/24).
 #define AIE_DEBUG_FLAG_MM2SBDFINISH_COUNTER (1 << 6)
+#define AIE_DEBUG_FLAG_CORE_PERF_COUNTER (1 << 8)
 // bit 7 reserved
 // bit 8 reserved
 /* When set, enable informational runtime log output (AIEHLC_LOG).
@@ -394,6 +404,17 @@ AieRC __Runtime_perfcnt_setup_mm2s_bd_finished_partition(XAie_DevInst *dev, uint
 // Read and print all MM2S BD finished perf counters across a partition.
 void __Runtime_perfcnt_read_mm2s_bd_finished_partition(XAie_DevInst *dev, uint8_t start_col, uint8_t end_col,
                                                        uint8_t start_row, uint8_t end_row);
+
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+
+AieRC __Runtime_core_perf_setup(XAie_DevInst *dev, XAie_LocType tile);
+AieRC __Runtime_core_perf_read(XAie_DevInst *dev, XAie_LocType tile, uint32_t *active, uint32_t *vec_instr,
+                               uint32_t *stream_stall, uint32_t *lock_stall);
+int __Runtime_core_perf_probe_valid(void);
+void __Runtime_core_perf_read_probe(uint32_t *active, uint32_t *vec_instr, uint32_t *stream_stall,
+                                    uint32_t *lock_stall);
+void __Runtime_perfcnt_read_mm2s_probe(uint32_t *ch0, uint32_t *ch1);
 
 // ---------------------------------------------------------------------------
 // DMA-capable buffer allocation with cache sync support

--- a/src/mlir/runtime/aie_runtime_debug.c
+++ b/src/mlir/runtime/aie_runtime_debug.c
@@ -1043,17 +1043,31 @@ void AieRt_PrintAllBds(XAie_DevInst *dev, XAie_LocType tile) {
  * -------------------------------------------------------------------------- */
 
 void AieRt_PrintShimBdRawAll(XAie_DevInst *dev, uint8_t col) {
-    printf("[AieRt_Debug] ===== Shim tile(%u,0) Raw BD Dump (16 BDs) =====\n", (unsigned)col);
+    uint32_t bd_base, bd_stride, bd_words;
+    const char *gen_tag;
+    if (g_aiert_gen == AIERT_GEN_AIE2PS) {
+        bd_base = AIERT_SHIM_BD_BASE_2PS;
+        bd_stride = AIERT_SHIM_BD_STRIDE_2PS;
+        bd_words = AIERT_SHIM_BD_WORDS_2PS;
+        gen_tag = "AIE2PS";
+    } else {
+        bd_base = AIERT_SHIM_BD_BASE_ML;
+        bd_stride = AIERT_SHIM_BD_STRIDE_ML;
+        bd_words = AIERT_SHIM_BD_WORDS_ML;
+        gen_tag = "AIEML";
+    }
+    printf("[AieRt_Debug] ===== Shim tile(%u,0) Raw BD Dump [%s] (16 BDs, base=0x%x stride=0x%x words=%u) =====\n",
+           (unsigned)col, gen_tag, (unsigned)bd_base, (unsigned)bd_stride, (unsigned)bd_words);
 
     int printed = 0;
+    u32 w[9];
     for (uint32_t bd = 0; bd < AIERT_SHIM_BD_COUNT; bd++) {
-        uint32_t base = AIERT_SHIM_BD_BASE + bd * AIERT_SHIM_BD_STRIDE;
-        u32 w[AIERT_SHIM_BD_WORDS];
+        uint32_t base = bd_base + bd * bd_stride;
 
-        /* Read all 8 words of this BD.
+        /* Read all words of this BD.
          * Shim tile address: (col << 25) | (row << 20) | reg_offset, row=0. */
         u64 tile_base = (u64)col << 25; /* shim row=0 */
-        for (uint32_t wi = 0; wi < AIERT_SHIM_BD_WORDS; wi++) {
+        for (uint32_t wi = 0; wi < bd_words; wi++) {
             AieRC rc = XAie_Read32(dev, tile_base | (u64)(base + wi * 4), &w[wi]);
             if (rc != XAIE_OK)
                 w[wi] = 0;
@@ -1096,23 +1110,25 @@ void AieRt_PrintShimBdRawAll(XAie_DevInst *dev, uint8_t col) {
         uint32_t iter_wrap = (w[6] >> 20) & 0x3Fu;
         uint32_t iter_curr = (w[6] >> 26) & 0x3Fu;
 
-        /* Decode word 7: Valid[0], Next_BD[4:1], Use_Next[5],
-         * Lock_Acq_Val[13:6], Lock_Acq_ID[17:14],
-         * Lock_Rel_Val[25:18], Lock_Rel_ID[29:26],
-         * Lock_Acq_En[30], Lock_Rel_En[31] */
-        uint32_t valid = w[7] & 0x1u;
-        uint32_t next_bd = (w[7] >> 1) & 0xFu;
-        uint32_t use_next = (w[7] >> 5) & 0x1u;
-        int32_t acq_val = (int32_t)((int8_t)((w[7] >> 6) & 0xFFu));
-        uint32_t acq_id = (w[7] >> 14) & 0xFu;
-        int32_t rel_val = (int32_t)((int8_t)((w[7] >> 18) & 0xFFu));
-        uint32_t rel_id = (w[7] >> 26) & 0xFu;
-        uint32_t acq_en = (w[7] >> 30) & 0x1u;
-        uint32_t rel_en = (w[7] >> 31) & 0x1u;
+        uint32_t lock_word = w[7];
+        uint32_t acq_id = lock_word & 0xFu;
+        int32_t acq_val = (int32_t)((int8_t)(((lock_word >> 5) & 0x7Fu) << 1) >> 1);
+        uint32_t acq_en = (lock_word >> 12) & 0x1u;
+        uint32_t rel_id = (lock_word >> 13) & 0xFu;
+        int32_t rel_val = (int32_t)((int8_t)(((lock_word >> 18) & 0x7Fu) << 1) >> 1);
+        uint32_t valid = (lock_word >> 25) & 0x1u;
+        uint32_t use_next = (lock_word >> 26) & 0x1u;
+        uint32_t next_bd = (lock_word >> 27) & 0xFu;
+        uint32_t rel_en = 0;
+        (void)rel_en;
 
         /* Print header with raw words */
-        printf("[AieRt_Debug]   BD%-2u raw: [%08x %08x %08x %08x %08x %08x %08x %08x]\n", (unsigned)bd, w[0], w[1],
-               w[2], w[3], w[4], w[5], w[6], w[7]);
+        if (bd_words == 9)
+            printf("[AieRt_Debug]   BD%-2u raw: [%08x %08x %08x %08x %08x %08x %08x %08x %08x]\n", (unsigned)bd, w[0],
+                   w[1], w[2], w[3], w[4], w[5], w[6], w[7], w[8]);
+        else
+            printf("[AieRt_Debug]   BD%-2u raw: [%08x %08x %08x %08x %08x %08x %08x %08x]\n", (unsigned)bd, w[0], w[1],
+                   w[2], w[3], w[4], w[5], w[6], w[7]);
 
         /* Print decoded fields */
         uint64_t full_addr = ((uint64_t)addr_hi << 32) | (uint64_t)addr_lo;
@@ -1558,6 +1574,12 @@ void AieRt_DebugSnapshot(XAie_DevInst *dev, const struct_io *ios, uint32_t num_i
 
     /* 12. IO verification */
     AieRt_VerifyIoDescriptors(dev, ios, num_ios);
+
+    printf("[AieRt_Debug] ===== Kernel Log (DM offset 0xF800) =====\n");
+    for (uint32_t i = 0; i < num_tiles; i++) {
+        if (s_is_core(tiles[i]))
+            __Runtime_read_kernel_log(dev, tiles[i]);
+    }
 
     printf("[AieRt_Debug] ============================================================\n\n");
 }

--- a/src/mlir/runtime/aie_runtime_debug.h
+++ b/src/mlir/runtime/aie_runtime_debug.h
@@ -396,11 +396,15 @@ void AieRt_PrintAllBds(XAie_DevInst *dev, XAie_LocType tile);
  *
  * Reads all 16 BD slots by directly accessing DMA BD registers via
  * XAie_Read32.  For each BD where word0 (Buffer_Length) is non-zero,
- * prints all 8 words decoded:
+ * prints all words decoded.  Offsets are generation-specific.
  *
- * AIE2PS/AIEML Shim NOC tile BD register layout (xregdb):
- *   Base offset: 0x1D000  (BD0), each BD is 8 words = 0x20 bytes apart
- *   16 BDs total: BD0 @ 0x1D000 .. BD15 @ 0x1D1E0
+ * AIEML Shim NOC tile BD layout (xaiemlgbl_params.h):
+ *   Base offset: 0x1D000, each BD is 8 words = 0x20 bytes apart
+ *   16 BDs: BD0 @ 0x1D000 .. BD15 @ 0x1D1E0
+ *
+ * AIE2PS Shim NOC tile BD layout (xaie2psgbl_params.h):
+ *   Base offset: 0x9000, each BD is 9 words = 0x30 bytes apart
+ *   16 BDs: BD0 @ 0x9000 .. BD15 @ 0x92D0
  *
  *   Word 0 (BD_0): Buffer_Length [31:0]
  *   Word 1 (BD_1): Base_Address_Low [31:0]
@@ -412,16 +416,31 @@ void AieRt_PrintAllBds(XAie_DevInst *dev, XAie_LocType tile);
  *   Word 5 (BD_5): D2_Stepsize [19:0], D2_Wrap [29:20]
  *   Word 6 (BD_6): Iteration_Stepsize [19:0], Iteration_Wrap [25:20],
  *                   Iteration_Current [31:26]
- *   Word 7 (BD_7): Valid_BD [0], Next_BD [4:1], Use_Next_BD [5],
- *                   Lock_Acq_Value [13:6], Lock_Acq_ID [17:14],
- *                   Lock_Rel_Value [25:18], Lock_Rel_ID [29:26],
- *                   Lock_Acq_Enable [30], Lock_Rel_Enable [31]
+ *   Word 7 (BD_7 / AIE2PS BD_7):
+ *     AIE2PS: D3_Stepsize [19:0], D3_Wrap [29:20]
+ *     AIEML:  Valid_BD [0], Next_BD [4:1], Use_Next_BD [5],
+ *             Lock_Acq_Value [13:6], Lock_Acq_ID [17:14],
+ *             Lock_Rel_Value [25:18], Lock_Rel_ID [29:26],
+ *             Lock_Acq_Enable [30], Lock_Rel_Enable [31]
+ *   Word 8 (BD_8, AIE2PS only):
+ *     Valid_BD [0], Next_BD [4:1], Use_Next_BD [5],
+ *     Lock_Acq_Value [13:6], Lock_Acq_ID [17:14],
+ *     Lock_Rel_Value [25:18], Lock_Rel_ID [29:26],
+ *     Lock_Acq_Enable [30], Lock_Rel_Enable [31]
  * -------------------------------------------------------------------------- */
 
-#define AIERT_SHIM_BD_BASE 0x0001D000u /* BD0 word0 offset in shim tile */
-#define AIERT_SHIM_BD_STRIDE 0x20u     /* 8 words * 4 bytes per BD */
-#define AIERT_SHIM_BD_COUNT 16u        /* 16 BDs per shim tile */
-#define AIERT_SHIM_BD_WORDS 8u         /* 8 x 32-bit words per BD */
+#define AIERT_SHIM_BD_BASE_ML 0x0001D000u
+#define AIERT_SHIM_BD_STRIDE_ML 0x20u
+#define AIERT_SHIM_BD_WORDS_ML 8u
+
+#define AIERT_SHIM_BD_BASE_2PS 0x00009000u
+#define AIERT_SHIM_BD_STRIDE_2PS 0x30u
+#define AIERT_SHIM_BD_WORDS_2PS 9u
+
+#define AIERT_SHIM_BD_BASE AIERT_SHIM_BD_BASE_ML
+#define AIERT_SHIM_BD_STRIDE AIERT_SHIM_BD_STRIDE_ML
+#define AIERT_SHIM_BD_COUNT 16u
+#define AIERT_SHIM_BD_WORDS AIERT_SHIM_BD_WORDS_ML
 
 /**
  * Dump all 16 raw BD registers for a shim tile.


### PR DESCRIPTION
New results for 256x256 GEMM.

```
Total Time:                 43.88ms
    Kernel load:                42.97ms
    Time excluding kernel load: 0.91ms

Total Time (skip-.bss on):  6.04ms
    Kernel load (skip-.bss on): 5.13ms
    Time excluding kernel load: 0.91ms
```

AEG example_oob_4x4 256x256 Comparison:
```
TOTAL                                  1.984 ms
    gr.init()                          0.055 ms
    input pack (1-time, 128 kB)        1.005 ms
    GEMM time                          0.924 ms
GEMM TIME BREAKDOWN                    0.924 ms 
    graph launch (gr.run, 1x)          0.024 ms
    input DMA issue                    0.041 ms
    output DMA issue                   0.014 ms
    gmio_wait (array drain)            0.601 ms
    host k-accum (cAcc += mem_out)     0.244 ms
```

There is also a faster version for AEG with some changes (WIP)
